### PR TITLE
Fix error reporting in view macro

### DIFF
--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -295,57 +295,40 @@ pub(crate) fn element_to_tokens(
             );
         }
 
-        let children = node.children.iter().map(|node| {
-            let (child, is_static) = match node {
-                Node::Fragment(fragment) => (
-                    fragment_to_tokens(
-                        &fragment.children,
-                        true,
-                        parent_type,
-                        None,
-                        global_class,
-                        None,
-                    )
-                    .unwrap_or(quote_spanned! {
-                        Span::call_site()=> ::leptos::leptos_dom::Unit
-                    }),
-                    false,
-                ),
-                Node::Text(node) => (quote! { #node }, true),
+        let children = node
+            .children
+            .iter()
+            .map(|node| match node {
+                Node::Fragment(fragment) => fragment_to_tokens(
+                    &fragment.children,
+                    true,
+                    parent_type,
+                    None,
+                    global_class,
+                    None,
+                )
+                .unwrap_or(quote_spanned! {
+                    Span::call_site()=> ::leptos::leptos_dom::Unit
+                }),
+                Node::Text(node) => quote! { #node },
                 Node::RawText(node) => {
                     let text = node.to_string_best();
                     let text = syn::LitStr::new(&text, node.span());
-                    (quote! { #text }, true)
+                    quote! { #text }
                 }
-                Node::Block(node) => (
-                    quote! {
-                       #node
-                    },
-                    false,
-                ),
-                Node::Element(node) => (
-                    element_to_tokens(
-                        node,
-                        parent_type,
-                        None,
-                        global_class,
-                        None,
-                    )
-                    .unwrap_or_default(),
-                    false,
-                ),
-                Node::Comment(_) | Node::Doctype(_) => (quote! {}, false),
-            };
-            if is_static {
-                quote! {
-                    .child(#child)
-                }
-            } else {
-                quote! {
-                    .child((#child))
-                }
-            }
-        });
+                Node::Block(node) => quote! { #node },
+                Node::Element(node) => element_to_tokens(
+                    node,
+                    parent_type,
+                    None,
+                    global_class,
+                    None,
+                )
+                .unwrap_or_default(),
+                Node::Comment(_) | Node::Doctype(_) => quote! {},
+            })
+            .map(|node| quote!(.child(#node)));
+
         let view_marker = if let Some(marker) = view_marker {
             quote! { .with_view_marker(#marker) }
         } else {

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -38,6 +38,7 @@ pub(crate) fn fragment_to_tokens(
     let mut nodes = nodes
         .iter()
         .filter_map(|node| {
+            let span = node.span();
             let node = node_to_tokens(
                 node,
                 parent_type,
@@ -46,8 +47,12 @@ pub(crate) fn fragment_to_tokens(
                 None,
             )?;
 
+            let node = quote_spanned! { span =>
+                #[allow(unused_braces)] {#node}
+            };
+
             Some(quote! {
-                ::leptos::IntoView::into_view(#[allow(unused_braces)] {#node})
+                ::leptos::IntoView::into_view(#node)
             })
         })
         .peekable();

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -335,7 +335,8 @@ pub(crate) fn element_to_tokens(
             quote! {}
         };
         let ide_helper_close_tag = ide_helper_close_tag.into_iter();
-        Some(quote! {
+        Some(quote_spanned! { node.span() =>
+            #[allow(unused_braces)]
             {
             #(#ide_helper_close_tag)*
             #name

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -52,7 +52,7 @@ pub(crate) fn fragment_to_tokens(
                 None,
             )?;
 
-            let node = quote_spanned! { span =>
+            let node = quote_spanned! {span=>
                 #[allow(unused_braces)] {#node}
             };
 
@@ -82,7 +82,7 @@ pub(crate) fn fragment_to_tokens(
     };
 
     let tokens = if lazy {
-        quote_spanned! { original_span =>
+        quote_spanned! {original_span=>
             {
                 ::leptos::Fragment::lazy(|| ::std::vec![
                     #(#nodes),*
@@ -91,7 +91,7 @@ pub(crate) fn fragment_to_tokens(
             }
         }
     } else {
-        quote_spanned! { original_span =>
+        quote_spanned! {original_span=>
             {
                 ::leptos::Fragment::new(::std::vec![
                     #(#nodes),*
@@ -335,7 +335,7 @@ pub(crate) fn element_to_tokens(
             quote! {}
         };
         let ide_helper_close_tag = ide_helper_close_tag.into_iter();
-        Some(quote_spanned! { node.span() =>
+        Some(quote_spanned! {node.span()=>
             #[allow(unused_braces)]
             {
             #(#ide_helper_close_tag)*

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -24,7 +24,6 @@ pub(crate) enum TagType {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn fragment_to_tokens(
-    _span: Span,
     nodes: &[Node],
     lazy: bool,
     parent_type: TagType,
@@ -123,7 +122,6 @@ pub(crate) fn node_to_tokens(
 ) -> Option<TokenStream> {
     match node {
         Node::Fragment(fragment) => fragment_to_tokens(
-            Span::call_site(),
             &fragment.children,
             true,
             parent_type,
@@ -308,7 +306,6 @@ pub(crate) fn element_to_tokens(
             let (child, is_static) = match node {
                 Node::Fragment(fragment) => (
                     fragment_to_tokens(
-                        Span::call_site(),
                         &fragment.children,
                         true,
                         parent_type,

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -246,7 +246,7 @@ pub(crate) fn element_to_tokens(
                             ..
                         }),
                         _,
-                    ) => Some(quote! { .attrs(#[allow(unused_brace)] {#end}) }),
+                    ) => Some(quote! { .attrs(#end) }),
                     _ => None,
                 }
             } else {

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -35,6 +35,12 @@ pub(crate) fn fragment_to_tokens(
     let mut slots = HashMap::new();
     let has_slots = parent_slots.is_some();
 
+    let original_span = nodes
+        .first()
+        .zip(nodes.last())
+        .and_then(|(first, last)| first.span().join(last.span()))
+        .unwrap_or_else(Span::call_site);
+
     let mut nodes = nodes
         .iter()
         .filter_map(|node| {
@@ -77,7 +83,7 @@ pub(crate) fn fragment_to_tokens(
     };
 
     let tokens = if lazy {
-        quote! {
+        quote_spanned! { original_span =>
             {
                 ::leptos::Fragment::lazy(|| ::std::vec![
                     #(#nodes),*
@@ -86,7 +92,7 @@ pub(crate) fn fragment_to_tokens(
             }
         }
     } else {
-        quote! {
+        quote_spanned! { original_span =>
             {
                 ::leptos::Fragment::new(::std::vec![
                     #(#nodes),*

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -178,7 +178,7 @@ pub(crate) fn element_to_tokens(
         let name = if is_custom_element(&tag) {
             let name = node.name().to_string();
             // link custom ident to name span for IDE docs
-            let custom = Ident::new("custom", name.span());
+            let custom = Ident::new("custom", node.name().span());
             quote! { ::leptos::leptos_dom::html::#custom(::leptos::leptos_dom::html::Custom::new(#name)) }
         } else if is_svg_element(&tag) {
             parent_type = TagType::Svg;
@@ -283,14 +283,7 @@ pub(crate) fn element_to_tokens(
         });
         let global_class_expr = match global_class {
             None => quote! {},
-            Some(class) => {
-                quote! {
-                    .classes(
-                        #[allow(unused_braces)]
-                        {#class}
-                    )
-                }
-            }
+            Some(class) => quote! { .classes(#class) },
         };
 
         if is_self_closing(node) && !node.children.is_empty() {
@@ -459,7 +452,7 @@ pub(crate) fn attribute_to_tokens(
             prop.span()=> .prop
         };
         quote! {
-            #prop(#name, #[allow(unused_braces)] {#value})
+            #prop(#name, #value)
         }
     } else if let Some(name) = name.strip_prefix("class:") {
         let value = attribute_value(node);
@@ -471,7 +464,7 @@ pub(crate) fn attribute_to_tokens(
             class.span()=> .class
         };
         quote! {
-            #class(#name, #[allow(unused_braces)] {#value})
+            #class(#name, #value)
         }
     } else if let Some(name) = name.strip_prefix("style:") {
         let value = attribute_value(node);
@@ -483,7 +476,7 @@ pub(crate) fn attribute_to_tokens(
             style.span()=> .style
         };
         quote! {
-            #style(#name, #[allow(unused_braces)] {#value})
+            #style(#name, #value)
         }
     } else {
         let name = name.replacen("attr:", "", 1);
@@ -526,7 +519,7 @@ pub(crate) fn attribute_to_tokens(
             }
         };
         quote! {
-            #attr(#name, (#value))
+            #attr(#name, #value)
         }
     }
 }

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::view::directive_call_from_attribute_node;
 use proc_macro2::{Ident, TokenStream, TokenTree};
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, quote_spanned};
 use rstml::node::{NodeAttribute, NodeElement};
 use std::collections::HashMap;
 use syn::spanned::Spanned;
@@ -189,6 +189,10 @@ pub(crate) fn component_to_tokens(
         quote! {}
     };
 
+    let build = quote_spanned! { name.span() =>
+        .build()
+    };
+
     #[allow(unused_mut)] // used in debug
     let mut component = quote! {
         ::leptos::component_view(
@@ -197,7 +201,7 @@ pub(crate) fn component_to_tokens(
                 #(#props)*
                 #(#slots)*
                 #children
-                .build()
+                #build
                 #dyn_attrs
         )
     };

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -195,15 +195,17 @@ pub(crate) fn component_to_tokens(
 
     #[allow(unused_mut)] // used in debug
     let mut component = quote! {
-        ::leptos::component_view(
-            &#name,
-            ::leptos::component_props_builder(&#name #generics)
+        {
+            let props = ::leptos::component_props_builder(&#name #generics)
                 #(#props)*
                 #(#slots)*
                 #children
                 #build
-                #dyn_attrs
-        )
+                #dyn_attrs;
+
+            #[allow(unreachable_code)]
+            ::leptos::component_view(&#name, props)
+        }
     };
 
     // (Temporarily?) removed

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -189,6 +189,10 @@ pub(crate) fn component_to_tokens(
         quote! {}
     };
 
+    let name_ref = quote_spanned! { name.span() =>
+        &#name
+    };
+
     let build = quote_spanned! { name.span() =>
         .build()
     };
@@ -196,7 +200,7 @@ pub(crate) fn component_to_tokens(
     #[allow(unused_mut)] // used in debug
     let mut component = quote! {
         {
-            let props = ::leptos::component_props_builder(&#name #generics)
+            let props = ::leptos::component_props_builder(#name_ref #generics)
                 #(#props)*
                 #(#slots)*
                 #children
@@ -204,7 +208,7 @@ pub(crate) fn component_to_tokens(
                 #dyn_attrs;
 
             #[allow(unreachable_code)]
-            ::leptos::component_view(&#name, props)
+            ::leptos::component_view(#name_ref, props)
         }
     };
 

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -146,9 +146,10 @@ pub(crate) fn component_to_tokens(
             let bindables =
                 items_to_bind.iter().map(|ident| quote! { #ident, });
 
-            let clonables = items_to_clone
-                .iter()
-                .map(|ident| quote! { let #ident = #ident.clone(); });
+            let clonables = items_to_clone.iter().map(|ident| {
+                let ident_ref = quote_spanned! { ident.span() => &#ident };
+                quote! { let #ident = ::core::clone::Clone::clone(#ident_ref); }
+            });
 
             if bindables.len() > 0 {
                 quote! {

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -81,9 +81,9 @@ pub(crate) fn component_to_tokens(
         .filter(|attr| attr.key.to_string().starts_with("on:"))
         .map(|attr| {
             let (event_type, handler) = event_from_attribute_node(attr, true);
-
+            let on = quote_spanned!(attr.key.span() => on);
             quote! {
-                .on(#event_type, #handler)
+                .#on(#event_type, #handler)
             }
         })
         .collect::<Vec<_>>();

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -18,7 +18,6 @@ pub(crate) fn component_to_tokens(
     let name = node.name();
     #[cfg(debug_assertions)]
     let component_name = ident_from_tag_name(node.name());
-    let span = node.name().span();
 
     let attrs = node.attributes().iter().filter_map(|node| {
         if let NodeAttribute::Attribute(node) = node {
@@ -124,7 +123,6 @@ pub(crate) fn component_to_tokens(
         quote! {}
     } else {
         let children = fragment_to_tokens(
-            span,
             &node.children,
             true,
             TagType::Unknown,

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -217,12 +217,19 @@ pub(crate) fn component_to_tokens(
             let props = #component_props_builder
                 #(#props)*
                 #(#slots)*
-                #children
+                #children;
+
+            #[allow(clippy::let_unit_value, clippy::unit_arg)]
+            let props = props
                 #build
                 #dyn_attrs;
 
             #[allow(unreachable_code)]
-            ::leptos::component_view(#name_ref, props)
+            ::leptos::component_view(
+                #[allow(clippy::needless_borrows_for_generic_args)]
+                #name_ref,
+                props
+            )
         }
     };
 

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -210,7 +210,7 @@ pub(crate) fn component_to_tokens(
     };
 
     #[allow(unused_mut)] // used in debug
-    let mut component = quote! {
+    let mut component = quote_spanned! { node.span() =>
         {
             let props = #component_props_builder
                 #(#props)*
@@ -232,7 +232,7 @@ pub(crate) fn component_to_tokens(
     if events_and_directives.is_empty() {
         component
     } else {
-        quote! {
+        quote_spanned! { node.span() =>
             ::leptos::IntoView::into_view(#[allow(unused_braces)] {#component})
             #(#events_and_directives)*
         }

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -173,6 +173,10 @@ pub(crate) fn component_to_tokens(
     };
 
     let slots = slots.drain().map(|(slot, values)| {
+        let span = values
+            .last()
+            .expect("List of slots must not be empty")
+            .span();
         let slot = Ident::new(&slot, span);
         if values.len() > 1 {
             quote! {

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -196,11 +196,14 @@ pub(crate) fn component_to_tokens(
     let build = quote_spanned! { name.span() =>
         .build()
     };
+    let component_props_builder = quote_spanned! { name.span() =>
+        ::leptos::component_props_builder(#name_ref #generics)
+    };
 
     #[allow(unused_mut)] // used in debug
     let mut component = quote! {
         {
-            let props = ::leptos::component_props_builder(#name_ref #generics)
+            let props = #component_props_builder
                 #(#props)*
                 #(#slots)*
                 #children

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -172,22 +172,23 @@ pub(crate) fn component_to_tokens(
         }
     };
 
-    let slots = slots.drain().map(|(slot, values)| {
+    let slots = slots.drain().map(|(slot, mut values)| {
         let span = values
             .last()
             .expect("List of slots must not be empty")
             .span();
         let slot = Ident::new(&slot, span);
-        if values.len() > 1 {
-            quote! {
-                .#slot(::std::vec![
+        let value = if values.len() > 1 {
+            quote_spanned! { span =>
+                ::std::vec![
                     #(#values)*
-                ])
+                ]
             }
         } else {
-            let value = &values[0];
-            quote! { .#slot(#value) }
-        }
+            values.remove(0)
+        };
+
+        quote! { .#slot(#value) }
     });
 
     let generics = &node.open_tag.generics;

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -47,8 +47,12 @@ pub(crate) fn component_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            quote! {
-                .#name(#[allow(unused_braces)] {#value})
+            let value = quote_spanned! { value.span() =>
+                #[allow(unused_braces)] {#value}
+            };
+
+            quote_spanned! { attr.span() =>
+                .#name(#value)
             }
         });
 

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -46,11 +46,11 @@ pub(crate) fn component_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            let value = quote_spanned! { value.span() =>
+            let value = quote_spanned! {value.span()=>
                 #[allow(unused_braces)] {#value}
             };
 
-            quote_spanned! { attr.span() =>
+            quote_spanned! {attr.span()=>
                 .#name(#value)
             }
         });
@@ -80,7 +80,7 @@ pub(crate) fn component_to_tokens(
         .filter(|attr| attr.key.to_string().starts_with("on:"))
         .map(|attr| {
             let (event_type, handler) = event_from_attribute_node(attr, true);
-            let on = quote_spanned!(attr.key.span() => on);
+            let on = quote_spanned!(attr.key.span()=> on);
             quote! {
                 .#on(#event_type, #handler)
             }
@@ -136,7 +136,7 @@ pub(crate) fn component_to_tokens(
                 let marker = format!("<{component_name}/>-children");
                 // For some reason spanning for `.children` breaks, unless `#view_marker`
                 // is also covered by `children.span()`.
-                let view_marker = quote_spanned! { children.span() => .with_view_marker(#marker) };
+                let view_marker = quote_spanned!(children.span()=> .with_view_marker(#marker));
             } else {
                 let view_marker = quote! {};
             }
@@ -147,12 +147,12 @@ pub(crate) fn component_to_tokens(
                 items_to_bind.iter().map(|ident| quote! { #ident, });
 
             let clonables = items_to_clone.iter().map(|ident| {
-                let ident_ref = quote_spanned! { ident.span() => &#ident };
+                let ident_ref = quote_spanned!(ident.span()=> &#ident);
                 quote! { let #ident = ::core::clone::Clone::clone(#ident_ref); }
             });
 
             if bindables.len() > 0 {
-                quote_spanned! { children.span() =>
+                quote_spanned! {children.span()=>
                     .children({
                         #(#clonables)*
 
@@ -160,7 +160,7 @@ pub(crate) fn component_to_tokens(
                     })
                 }
             } else {
-                quote_spanned! { children.span() =>
+                quote_spanned! {children.span()=>
                     .children({
                         #(#clonables)*
 
@@ -180,7 +180,7 @@ pub(crate) fn component_to_tokens(
             .span();
         let slot = Ident::new(&slot, span);
         let value = if values.len() > 1 {
-            quote_spanned! { span =>
+            quote_spanned! {span=>
                 ::std::vec![
                     #(#values)*
                 ]
@@ -199,20 +199,20 @@ pub(crate) fn component_to_tokens(
         quote! {}
     };
 
-    let name_ref = quote_spanned! { name.span() =>
+    let name_ref = quote_spanned! {name.span()=>
         &#name
     };
 
-    let build = quote_spanned! { name.span() =>
+    let build = quote_spanned! {name.span()=>
         .build()
     };
 
-    let component_props_builder = quote_spanned! { name.span() =>
+    let component_props_builder = quote_spanned! {name.span()=>
         ::leptos::component_props_builder(#name_ref #generics)
     };
 
     #[allow(unused_mut)] // used in debug
-    let mut component = quote_spanned! { node.span() =>
+    let mut component = quote_spanned! {node.span()=>
         {
             let props = #component_props_builder
                 #(#props)*
@@ -234,7 +234,7 @@ pub(crate) fn component_to_tokens(
     if events_and_directives.is_empty() {
         component
     } else {
-        quote_spanned! { node.span() =>
+        quote_spanned! {node.span()=>
             ::leptos::IntoView::into_view(#[allow(unused_braces)] {#component})
             #(#events_and_directives)*
         }

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -38,7 +38,6 @@ pub(crate) fn render_view(
                 call_site,
             ),
             _ => server_template::fragment_to_tokens_ssr(
-                Span::call_site(),
                 nodes,
                 global_class,
                 call_site,
@@ -56,7 +55,6 @@ pub(crate) fn render_view(
             )
             .unwrap_or_default(),
             _ => client_builder::fragment_to_tokens(
-                Span::call_site(),
                 nodes,
                 true,
                 client_builder::TagType::Unknown,

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -420,7 +420,7 @@ fn fancy_class_name<'a>(
                 let value = &tuple.elems[1];
                 return Some((
                     quote! {
-                        #class(#class_name, (#value))
+                        #class(#class_name, #value)
                     },
                     class_name,
                     value,
@@ -489,7 +489,7 @@ fn fancy_style_name<'a>(
                 let value = &tuple.elems[1];
                 return Some((
                     quote! {
-                        #style(#style_name, (#value))
+                        #style(#style_name, #value)
                     },
                     style_name,
                     value,

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -540,5 +540,5 @@ pub(crate) fn directive_call_from_attribute_node(
         quote_spanned!(attr.key.span()=> ().into())
     };
 
-    quote! { .directive(#handler, #param) }
+    quote! { .directive(#handler, #[allow(clippy::useless_conversion)] #param) }
 }

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -535,9 +535,9 @@ pub(crate) fn directive_call_from_attribute_node(
     let handler = syn::Ident::new(directive_name, attr.key.span());
 
     let param = if let Some(value) = attr.value() {
-        quote! { ::std::convert::Into::into(#value) }
+        quote!(::std::convert::Into::into(#value))
     } else {
-        quote_spanned! { attr.key.span() => ().into() }
+        quote_spanned!(attr.key.span()=> ().into())
     };
 
     quote! { .directive(#handler, #param) }

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -539,7 +539,7 @@ pub(crate) fn directive_call_from_attribute_node(
     let param = if let Some(value) = attr.value() {
         quote! { ::std::convert::Into::into(#value) }
     } else {
-        quote! { ().into() }
+        quote_spanned! { attr.key.span() => ().into() }
     };
 
     quote! { .directive(#handler, #param) }

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -385,14 +385,14 @@ fn element_to_tokens_ssr(
                                     })
                                 }
                                 chunks.push(SsrElementChunks::View(quote! {
-                                    ::leptos::IntoView::into_view(#[allow(unused_braces)] {#block})
+                                    ::leptos::IntoView::into_view(#block)
                                 }));
                             }
                         }
                         // Keep invalid blocks for faster IDE diff (on user type)
                         Node::Block(block @ NodeBlock::Invalid { .. }) => {
                             chunks.push(SsrElementChunks::View(quote! {
-                                ::leptos::IntoView::into_view(#[allow(unused_braces)] {#block})
+                                ::leptos::IntoView::into_view(#block)
                             }));
                         }
                         Node::Fragment(_) => abort!(
@@ -473,7 +473,7 @@ fn attribute_to_tokens_ssr<'a>(
                 } else {
                     template.push_str("{}");
                     holes.push(quote! {
-                        &::leptos::IntoAttribute::into_attribute(#[allow(unused_braces)] {#value})
+                        &::leptos::IntoAttribute::into_attribute(#value)
                             .as_nameless_value_string()
                             .map(|a| ::std::format!(
                                 "{}=\"{}\"",

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -83,7 +83,7 @@ pub(crate) fn fragment_to_tokens_ssr(
     let nodes = nodes.iter().map(|node| {
         let span = node.span();
         let node = root_node_to_tokens_ssr(node, global_class, None);
-        let node = quote_spanned! { span =>
+        let node = quote_spanned! {span=>
             #[allow(unused_braces)] {#node}
         };
 
@@ -92,7 +92,7 @@ pub(crate) fn fragment_to_tokens_ssr(
         }
     });
 
-    quote_spanned! { original_span =>
+    quote_spanned! {original_span=>
         {
             ::leptos::Fragment::lazy(|| ::std::vec![
                 #(#nodes),*

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -292,8 +292,10 @@ fn element_to_tokens_ssr(
                     // should basically be the resolved attributes, joined on spaces, placed into
                     // the template
                     template.push_str(" {}");
-                    holes.push(quote! {
-                        {#end}.into_iter().filter_map(|(name, attr)| {
+                    let end_into_iter =
+                        quote_spanned!(end.span()=> {#end}.into_iter());
+                    holes.push(quote_spanned! {block.span()=>
+                        #end_into_iter.filter_map(|(name, attr)| {
                            Some(::std::format!(
                                 "{}=\"{}\"",
                                 name,

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -12,7 +12,7 @@ use leptos_hot_reload::parsing::{
     block_to_primitive_expression, is_component_node, value_to_string,
 };
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use quote::quote;
+use quote::{quote, quote_spanned};
 use rstml::node::{
     KeyedAttribute, Node, NodeAttribute, NodeBlock, NodeElement,
 };
@@ -76,9 +76,14 @@ pub(crate) fn fragment_to_tokens_ssr(
         quote! {}
     };
     let nodes = nodes.iter().map(|node| {
+        let span = node.span();
         let node = root_node_to_tokens_ssr(node, global_class, None);
+        let node = quote_spanned! { span =>
+            #[allow(unused_braces)] {#node}
+        };
+
         quote! {
-            ::leptos::IntoView::into_view(#[allow(unused_braces)] {#node})
+            ::leptos::IntoView::into_view(#node)
         }
     });
     quote! {

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -34,7 +34,6 @@ pub(crate) fn root_node_to_tokens_ssr(
 ) -> TokenStream {
     match node {
         Node::Fragment(fragment) => fragment_to_tokens_ssr(
-            Span::call_site(),
             &fragment.children,
             global_class,
             view_marker,
@@ -65,7 +64,6 @@ pub(crate) fn root_node_to_tokens_ssr(
 }
 
 pub(crate) fn fragment_to_tokens_ssr(
-    _span: Span,
     nodes: &[Node],
     global_class: Option<&TokenTree>,
     view_marker: Option<String>,

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -163,12 +163,16 @@ pub(crate) fn slot_to_tokens(
     });
 
     let slot = quote_spanned! { node.span() =>
-        #component_name::builder()
-            #(#props)*
-            #(#slots)*
-            #children
-            .build()
-            .into(),
+        #[allow(unused_braces)] {
+            let slot = #component_name::builder()
+                #(#props)*
+                #(#slots)*
+                #children
+                .build();
+
+            #[allow(unreachable_code)]
+            slot.into()
+        },
     };
 
     parent_slots

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -157,7 +157,7 @@ pub(crate) fn slot_to_tokens(
         }
     });
 
-    let slot = quote! {
+    let slot = quote_spanned! { node.span() =>
         #component_name::builder()
             #(#props)*
             #(#slots)*

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -117,9 +117,10 @@ pub(crate) fn slot_to_tokens(
             let bindables =
                 items_to_bind.iter().map(|ident| quote! { #ident, });
 
-            let clonables = items_to_clone
-                .iter()
-                .map(|ident| quote! { let #ident = #ident.clone(); });
+            let clonables = items_to_clone.iter().map(|ident| {
+                let ident_ref = quote_spanned! { ident.span() => &#ident };
+                quote! { let #ident = ::core::clone::Clone::clone(#ident_ref); }
+            });
 
             if bindables.len() > 0 {
                 quote! {

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -162,13 +162,17 @@ pub(crate) fn slot_to_tokens(
         quote! { .#slot(#value) }
     });
 
+    let build = quote_spanned! { node.name().span() =>
+        .build()
+    };
+
     let slot = quote_spanned! { node.span() =>
         #[allow(unused_braces)] {
             let slot = #component_name::builder()
                 #(#props)*
                 #(#slots)*
                 #children
-                .build();
+                #build;
 
             #[allow(unreachable_code)]
             slot.into()

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -175,7 +175,7 @@ pub(crate) fn slot_to_tokens(
                 #children
                 #build;
 
-            #[allow(unreachable_code)]
+            #[allow(unreachable_code, clippy::useless_conversion)]
             slot.into()
         },
     };

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -23,11 +23,10 @@ pub(crate) fn slot_to_tokens(
     });
 
     let component_name = ident_from_tag_name(node.name());
-    let span = node.name().span();
 
     let Some(parent_slots) = parent_slots else {
         proc_macro_error::emit_error!(
-            span,
+            node.name().span(),
             "slots cannot be used inside HTML elements"
         );
         return;
@@ -95,7 +94,6 @@ pub(crate) fn slot_to_tokens(
         quote! {}
     } else {
         let children = fragment_to_tokens(
-            span,
             &node.children,
             true,
             TagType::Unknown,

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -3,7 +3,7 @@ use super::{
     convert_to_snake_case, ident_from_tag_name,
 };
 use proc_macro2::{Ident, TokenStream, TokenTree};
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, quote_spanned};
 use rstml::node::{KeyedAttribute, NodeAttribute, NodeElement};
 use std::collections::HashMap;
 use syn::spanned::Spanned;
@@ -61,8 +61,12 @@ pub(crate) fn slot_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            quote! {
-                .#name(#[allow(unused_braces)] {#value})
+            let value = quote_spanned! { value.span() =>
+                #[allow(unused_braces)] {#value}
+            };
+
+            quote_spanned! { attr.span() =>
+                .#name(#value)
             }
         });
 

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -143,22 +143,23 @@ pub(crate) fn slot_to_tokens(
         }
     };
 
-    let slots = slots.drain().map(|(slot, values)| {
+    let slots = slots.drain().map(|(slot, mut values)| {
         let span = values
             .last()
             .expect("List of slots must not be empty")
             .span();
         let slot = Ident::new(&slot, span);
-        if values.len() > 1 {
-            quote! {
-                .#slot(::std::vec![
+        let value = if values.len() > 1 {
+            quote_spanned! { span =>
+                ::std::vec![
                     #(#values)*
-                ])
+                ]
             }
         } else {
-            let value = &values[0];
-            quote! { .#slot(#value) }
-        }
+            values.remove(0)
+        };
+
+        quote! { .#slot(#value) }
     });
 
     let slot = quote_spanned! { node.span() =>

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -60,11 +60,11 @@ pub(crate) fn slot_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            let value = quote_spanned! { value.span() =>
+            let value = quote_spanned! {value.span()=>
                 #[allow(unused_braces)] {#value}
             };
 
-            quote_spanned! { attr.span() =>
+            quote_spanned! {attr.span()=>
                 .#name(#value)
             }
         });
@@ -107,7 +107,7 @@ pub(crate) fn slot_to_tokens(
                 let marker = format!("<{component_name}/>-children");
                 // For some reason spanning for `.children` breaks, unless `#view_marker`
                 // is also covered by `children.span()`.
-                let view_marker = quote_spanned! { children.span() => .with_view_marker(#marker) };
+                let view_marker = quote_spanned!(children.span()=> .with_view_marker(#marker));
             } else {
                 let view_marker = quote! {};
             }
@@ -118,12 +118,12 @@ pub(crate) fn slot_to_tokens(
                 items_to_bind.iter().map(|ident| quote! { #ident, });
 
             let clonables = items_to_clone.iter().map(|ident| {
-                let ident_ref = quote_spanned! { ident.span() => &#ident };
+                let ident_ref = quote_spanned!(ident.span()=> &#ident);
                 quote! { let #ident = ::core::clone::Clone::clone(#ident_ref); }
             });
 
             if bindables.len() > 0 {
-                quote_spanned! { children.span() =>
+                quote_spanned! {children.span()=>
                     .children({
                         #(#clonables)*
 
@@ -131,7 +131,7 @@ pub(crate) fn slot_to_tokens(
                     })
                 }
             } else {
-                quote_spanned! { children.span() =>
+                quote_spanned! {children.span()=>
                     .children({
                         #(#clonables)*
 
@@ -151,7 +151,7 @@ pub(crate) fn slot_to_tokens(
             .span();
         let slot = Ident::new(&slot, span);
         let value = if values.len() > 1 {
-            quote_spanned! { span =>
+            quote_spanned! {span=>
                 ::std::vec![
                     #(#values)*
                 ]
@@ -163,11 +163,11 @@ pub(crate) fn slot_to_tokens(
         quote! { .#slot(#value) }
     });
 
-    let build = quote_spanned! { node.name().span() =>
+    let build = quote_spanned! {node.name().span()=>
         .build()
     };
 
-    let slot = quote_spanned! { node.span() =>
+    let slot = quote_spanned! {node.span()=>
         #[allow(unused_braces)] {
             let slot = #component_name::builder()
                 #(#props)*

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -144,6 +144,10 @@ pub(crate) fn slot_to_tokens(
     };
 
     let slots = slots.drain().map(|(slot, values)| {
+        let span = values
+            .last()
+            .expect("List of slots must not be empty")
+            .span();
         let slot = Ident::new(&slot, span);
         if values.len() > 1 {
             quote! {

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__counter_component.snap
@@ -1,14 +1,15 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
-    ::leptos::component_view(
-        &SimpleCounter,
-        ::leptos::component_props_builder(&SimpleCounter)
+    {
+        let props = ::leptos::component_props_builder(&SimpleCounter)
             .initial_value(#[allow(unused_braces)] { 0 })
             .step(#[allow(unused_braces)] { 1 })
-            .build(),
-    )
+            .build();
+        #[allow(unreachable_code)] ::leptos::component_view(&SimpleCounter, props)
+    }
 }
 

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__custom_event.snap
@@ -1,15 +1,18 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
     ::leptos::IntoView::into_view(
             #[allow(unused_braces)]
             {
-                ::leptos::component_view(
-                    &ExternalComponent,
-                    ::leptos::component_props_builder(&ExternalComponent).build(),
-                )
+                {
+                    let props = ::leptos::component_props_builder(&ExternalComponent)
+                        .build();
+                    #[allow(unreachable_code)]
+                    ::leptos::component_view(&ExternalComponent, props)
+                }
             },
         )
         .on(

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__counter_component.snap
@@ -1,66 +1,52 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: result
 ---
 TokenStream [
-    Punct {
-        char: ':',
-        spacing: Joint,
-    },
-    Punct {
-        char: ':',
-        spacing: Alone,
-    },
-    Ident {
-        sym: leptos,
-    },
-    Punct {
-        char: ':',
-        spacing: Joint,
-    },
-    Punct {
-        char: ':',
-        spacing: Alone,
-    },
-    Ident {
-        sym: component_view,
-    },
     Group {
-        delimiter: Parenthesis,
+        delimiter: Brace,
         stream: TokenStream [
-            Punct {
-                char: '&',
-                spacing: Alone,
+            Ident {
+                sym: let,
+                span: bytes(10..82),
             },
             Ident {
-                sym: SimpleCounter,
+                sym: props,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: '=',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
                 span: bytes(11..24),
             },
             Punct {
-                char: ',',
-                spacing: Alone,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
                 char: ':',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: leptos,
+                span: bytes(11..24),
             },
             Punct {
                 char: ':',
                 spacing: Joint,
+                span: bytes(11..24),
             },
             Punct {
                 char: ':',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: component_props_builder,
+                span: bytes(11..24),
             },
             Group {
                 delimiter: Parenthesis,
@@ -68,16 +54,19 @@ TokenStream [
                     Punct {
                         char: '&',
                         spacing: Alone,
+                        span: bytes(11..24),
                     },
                     Ident {
                         sym: SimpleCounter,
                         span: bytes(11..24),
                     },
                 ],
+                span: bytes(11..24),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(37..52),
             },
             Ident {
                 sym: initial_value,
@@ -89,22 +78,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
+                        span: bytes(51..52),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
+                                span: bytes(51..52),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
+                                        span: bytes(51..52),
                                     },
                                 ],
+                                span: bytes(51..52),
                             },
                         ],
+                        span: bytes(51..52),
                     },
                     Group {
                         delimiter: Brace,
@@ -114,12 +108,15 @@ TokenStream [
                                 span: bytes(51..52),
                             },
                         ],
+                        span: bytes(51..52),
                     },
                 ],
+                span: bytes(37..52),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(65..71),
             },
             Ident {
                 sym: step,
@@ -131,22 +128,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
+                        span: bytes(70..71),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
+                                span: bytes(70..71),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
+                                        span: bytes(70..71),
                                     },
                                 ],
+                                span: bytes(70..71),
                             },
                         ],
+                        span: bytes(70..71),
                     },
                     Group {
                         delimiter: Brace,
@@ -156,20 +158,108 @@ TokenStream [
                                 span: bytes(70..71),
                             },
                         ],
+                        span: bytes(70..71),
                     },
                 ],
+                span: bytes(65..71),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: build,
+                span: bytes(11..24),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [],
+                span: bytes(11..24),
+            },
+            Punct {
+                char: ';',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: '#',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        sym: allow,
+                        span: bytes(10..82),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                sym: unreachable_code,
+                                span: bytes(10..82),
+                            },
+                        ],
+                        span: bytes(10..82),
+                    },
+                ],
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Ident {
+                sym: leptos,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Ident {
+                sym: component_view,
+                span: bytes(10..82),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: '&',
+                        spacing: Alone,
+                        span: bytes(11..24),
+                    },
+                    Ident {
+                        sym: SimpleCounter,
+                        span: bytes(11..24),
+                    },
+                    Punct {
+                        char: ',',
+                        spacing: Alone,
+                        span: bytes(10..82),
+                    },
+                    Ident {
+                        sym: props,
+                        span: bytes(10..82),
+                    },
+                ],
+                span: bytes(10..82),
             },
         ],
+        span: bytes(10..82),
     },
 ]

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__custom_event.snap
@@ -1,40 +1,50 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: result
 ---
 TokenStream [
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: leptos,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: IntoView,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: into_view,
+        span: bytes(10..82),
     },
     Group {
         delimiter: Parenthesis,
@@ -42,84 +52,74 @@ TokenStream [
             Punct {
                 char: '#',
                 spacing: Alone,
+                span: bytes(10..82),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         sym: allow,
+                        span: bytes(10..82),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 sym: unused_braces,
+                                span: bytes(10..82),
                             },
                         ],
+                        span: bytes(10..82),
                     },
                 ],
+                span: bytes(10..82),
             },
             Group {
                 delimiter: Brace,
                 stream: TokenStream [
-                    Punct {
-                        char: ':',
-                        spacing: Joint,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: leptos,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Joint,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: component_view,
-                    },
                     Group {
-                        delimiter: Parenthesis,
+                        delimiter: Brace,
                         stream: TokenStream [
-                            Punct {
-                                char: '&',
-                                spacing: Alone,
+                            Ident {
+                                sym: let,
+                                span: bytes(10..82),
                             },
                             Ident {
-                                sym: ExternalComponent,
+                                sym: props,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: '=',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
                                 span: bytes(11..28),
                             },
                             Punct {
-                                char: ',',
-                                spacing: Alone,
-                            },
-                            Punct {
-                                char: ':',
-                                spacing: Joint,
-                            },
-                            Punct {
                                 char: ':',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: leptos,
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: ':',
                                 spacing: Joint,
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: ':',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: component_props_builder,
+                                span: bytes(11..28),
                             },
                             Group {
                                 delimiter: Parenthesis,
@@ -127,29 +127,119 @@ TokenStream [
                                     Punct {
                                         char: '&',
                                         spacing: Alone,
+                                        span: bytes(11..28),
                                     },
                                     Ident {
                                         sym: ExternalComponent,
                                         span: bytes(11..28),
                                     },
                                 ],
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: '.',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: build,
+                                span: bytes(11..28),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [],
+                                span: bytes(11..28),
+                            },
+                            Punct {
+                                char: ';',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: '#',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        sym: allow,
+                                        span: bytes(10..82),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                sym: unreachable_code,
+                                                span: bytes(10..82),
+                                            },
+                                        ],
+                                        span: bytes(10..82),
+                                    },
+                                ],
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Ident {
+                                sym: leptos,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Ident {
+                                sym: component_view,
+                                span: bytes(10..82),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: '&',
+                                        spacing: Alone,
+                                        span: bytes(11..28),
+                                    },
+                                    Ident {
+                                        sym: ExternalComponent,
+                                        span: bytes(11..28),
+                                    },
+                                    Punct {
+                                        char: ',',
+                                        spacing: Alone,
+                                        span: bytes(10..82),
+                                    },
+                                    Ident {
+                                        sym: props,
+                                        span: bytes(10..82),
+                                    },
+                                ],
+                                span: bytes(10..82),
                             },
                         ],
+                        span: bytes(10..82),
                     },
                 ],
+                span: bytes(10..82),
             },
         ],
+        span: bytes(10..82),
     },
     Punct {
         char: '.',
@@ -157,6 +247,7 @@ TokenStream [
     },
     Ident {
         sym: on,
+        span: bytes(29..50),
     },
     Group {
         delimiter: Parenthesis,

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__counter_component.snap
@@ -1,14 +1,15 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
-    ::leptos::component_view(
-        &SimpleCounter,
-        ::leptos::component_props_builder(&SimpleCounter)
+    {
+        let props = ::leptos::component_props_builder(&SimpleCounter)
             .initial_value(#[allow(unused_braces)] { 0 })
             .step(#[allow(unused_braces)] { 1 })
-            .build(),
-    )
+            .build();
+        #[allow(unreachable_code)] ::leptos::component_view(&SimpleCounter, props)
+    }
 }
 

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__custom_event.snap
@@ -1,15 +1,18 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
     ::leptos::IntoView::into_view(
             #[allow(unused_braces)]
             {
-                ::leptos::component_view(
-                    &ExternalComponent,
-                    ::leptos::component_props_builder(&ExternalComponent).build(),
-                )
+                {
+                    let props = ::leptos::component_props_builder(&ExternalComponent)
+                        .build();
+                    #[allow(unreachable_code)]
+                    ::leptos::component_view(&ExternalComponent, props)
+                }
             },
         )
         .on(

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__counter_component.snap
@@ -1,66 +1,52 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: result
 ---
 TokenStream [
-    Punct {
-        char: ':',
-        spacing: Joint,
-    },
-    Punct {
-        char: ':',
-        spacing: Alone,
-    },
-    Ident {
-        sym: leptos,
-    },
-    Punct {
-        char: ':',
-        spacing: Joint,
-    },
-    Punct {
-        char: ':',
-        spacing: Alone,
-    },
-    Ident {
-        sym: component_view,
-    },
     Group {
-        delimiter: Parenthesis,
+        delimiter: Brace,
         stream: TokenStream [
-            Punct {
-                char: '&',
-                spacing: Alone,
+            Ident {
+                sym: let,
+                span: bytes(10..82),
             },
             Ident {
-                sym: SimpleCounter,
+                sym: props,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: '=',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
                 span: bytes(11..24),
             },
             Punct {
-                char: ',',
-                spacing: Alone,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
                 char: ':',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: leptos,
+                span: bytes(11..24),
             },
             Punct {
                 char: ':',
                 spacing: Joint,
+                span: bytes(11..24),
             },
             Punct {
                 char: ':',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: component_props_builder,
+                span: bytes(11..24),
             },
             Group {
                 delimiter: Parenthesis,
@@ -68,16 +54,19 @@ TokenStream [
                     Punct {
                         char: '&',
                         spacing: Alone,
+                        span: bytes(11..24),
                     },
                     Ident {
                         sym: SimpleCounter,
                         span: bytes(11..24),
                     },
                 ],
+                span: bytes(11..24),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(37..52),
             },
             Ident {
                 sym: initial_value,
@@ -89,22 +78,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
+                        span: bytes(51..52),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
+                                span: bytes(51..52),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
+                                        span: bytes(51..52),
                                     },
                                 ],
+                                span: bytes(51..52),
                             },
                         ],
+                        span: bytes(51..52),
                     },
                     Group {
                         delimiter: Brace,
@@ -114,12 +108,15 @@ TokenStream [
                                 span: bytes(51..52),
                             },
                         ],
+                        span: bytes(51..52),
                     },
                 ],
+                span: bytes(37..52),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(65..71),
             },
             Ident {
                 sym: step,
@@ -131,22 +128,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
+                        span: bytes(70..71),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
+                                span: bytes(70..71),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
+                                        span: bytes(70..71),
                                     },
                                 ],
+                                span: bytes(70..71),
                             },
                         ],
+                        span: bytes(70..71),
                     },
                     Group {
                         delimiter: Brace,
@@ -156,20 +158,108 @@ TokenStream [
                                 span: bytes(70..71),
                             },
                         ],
+                        span: bytes(70..71),
                     },
                 ],
+                span: bytes(65..71),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: build,
+                span: bytes(11..24),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [],
+                span: bytes(11..24),
+            },
+            Punct {
+                char: ';',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: '#',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        sym: allow,
+                        span: bytes(10..82),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                sym: unreachable_code,
+                                span: bytes(10..82),
+                            },
+                        ],
+                        span: bytes(10..82),
+                    },
+                ],
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Ident {
+                sym: leptos,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Ident {
+                sym: component_view,
+                span: bytes(10..82),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: '&',
+                        spacing: Alone,
+                        span: bytes(11..24),
+                    },
+                    Ident {
+                        sym: SimpleCounter,
+                        span: bytes(11..24),
+                    },
+                    Punct {
+                        char: ',',
+                        spacing: Alone,
+                        span: bytes(10..82),
+                    },
+                    Ident {
+                        sym: props,
+                        span: bytes(10..82),
+                    },
+                ],
+                span: bytes(10..82),
             },
         ],
+        span: bytes(10..82),
     },
 ]

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__custom_event.snap
@@ -1,40 +1,50 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: result
 ---
 TokenStream [
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: leptos,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: IntoView,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: into_view,
+        span: bytes(10..82),
     },
     Group {
         delimiter: Parenthesis,
@@ -42,84 +52,74 @@ TokenStream [
             Punct {
                 char: '#',
                 spacing: Alone,
+                span: bytes(10..82),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         sym: allow,
+                        span: bytes(10..82),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 sym: unused_braces,
+                                span: bytes(10..82),
                             },
                         ],
+                        span: bytes(10..82),
                     },
                 ],
+                span: bytes(10..82),
             },
             Group {
                 delimiter: Brace,
                 stream: TokenStream [
-                    Punct {
-                        char: ':',
-                        spacing: Joint,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: leptos,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Joint,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: component_view,
-                    },
                     Group {
-                        delimiter: Parenthesis,
+                        delimiter: Brace,
                         stream: TokenStream [
-                            Punct {
-                                char: '&',
-                                spacing: Alone,
+                            Ident {
+                                sym: let,
+                                span: bytes(10..82),
                             },
                             Ident {
-                                sym: ExternalComponent,
+                                sym: props,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: '=',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
                                 span: bytes(11..28),
                             },
                             Punct {
-                                char: ',',
-                                spacing: Alone,
-                            },
-                            Punct {
-                                char: ':',
-                                spacing: Joint,
-                            },
-                            Punct {
                                 char: ':',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: leptos,
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: ':',
                                 spacing: Joint,
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: ':',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: component_props_builder,
+                                span: bytes(11..28),
                             },
                             Group {
                                 delimiter: Parenthesis,
@@ -127,29 +127,119 @@ TokenStream [
                                     Punct {
                                         char: '&',
                                         spacing: Alone,
+                                        span: bytes(11..28),
                                     },
                                     Ident {
                                         sym: ExternalComponent,
                                         span: bytes(11..28),
                                     },
                                 ],
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: '.',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: build,
+                                span: bytes(11..28),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [],
+                                span: bytes(11..28),
+                            },
+                            Punct {
+                                char: ';',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: '#',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        sym: allow,
+                                        span: bytes(10..82),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                sym: unreachable_code,
+                                                span: bytes(10..82),
+                                            },
+                                        ],
+                                        span: bytes(10..82),
+                                    },
+                                ],
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Ident {
+                                sym: leptos,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Ident {
+                                sym: component_view,
+                                span: bytes(10..82),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: '&',
+                                        spacing: Alone,
+                                        span: bytes(11..28),
+                                    },
+                                    Ident {
+                                        sym: ExternalComponent,
+                                        span: bytes(11..28),
+                                    },
+                                    Punct {
+                                        char: ',',
+                                        spacing: Alone,
+                                        span: bytes(10..82),
+                                    },
+                                    Ident {
+                                        sym: props,
+                                        span: bytes(10..82),
+                                    },
+                                ],
+                                span: bytes(10..82),
                             },
                         ],
+                        span: bytes(10..82),
                     },
                 ],
+                span: bytes(10..82),
             },
         ],
+        span: bytes(10..82),
     },
     Punct {
         char: '.',
@@ -157,6 +247,7 @@ TokenStream [
     },
     Ident {
         sym: on,
+        span: bytes(29..50),
     },
     Group {
         delimiter: Parenthesis,

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__simple_counter.snap
@@ -1,8 +1,34 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: result
 ---
 TokenStream [
+    Punct {
+        char: '#',
+        spacing: Alone,
+        span: bytes(10..331),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                sym: allow,
+                span: bytes(10..331),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        sym: unused_braces,
+                        span: bytes(10..331),
+                    },
+                ],
+                span: bytes(10..331),
+            },
+        ],
+        span: bytes(10..331),
+    },
     Group {
         delimiter: Brace,
         stream: TokenStream [
@@ -124,223 +150,244 @@ TokenStream [
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
+                    Punct {
+                        char: '#',
+                        spacing: Alone,
+                        span: bytes(28..83),
+                    },
                     Group {
-                        delimiter: Parenthesis,
+                        delimiter: Bracket,
                         stream: TokenStream [
+                            Ident {
+                                sym: allow,
+                                span: bytes(28..83),
+                            },
                             Group {
-                                delimiter: Brace,
+                                delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
-                                        sym: let,
+                                        sym: unused_braces,
+                                        span: bytes(28..83),
+                                    },
+                                ],
+                                span: bytes(28..83),
+                            },
+                        ],
+                        span: bytes(28..83),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Ident {
+                                sym: let,
+                            },
+                            Ident {
+                                sym: _,
+                            },
+                            Punct {
+                                char: '=',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos_dom,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: html,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: button,
+                                span: bytes(76..82),
+                            },
+                            Punct {
+                                char: ';',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos_dom,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: html,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: button,
+                                span: bytes(29..35),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                                span: bytes(36..38),
+                            },
+                            Ident {
+                                sym: on,
+                                span: bytes(36..38),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: leptos,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: ev,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: click,
+                                        span: bytes(39..44),
+                                    },
+                                    Punct {
+                                        char: ',',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: move,
+                                        span: bytes(45..49),
+                                    },
+                                    Punct {
+                                        char: '|',
+                                        spacing: Alone,
+                                        span: bytes(50..51),
                                     },
                                     Ident {
                                         sym: _,
+                                        span: bytes(51..52),
                                     },
                                     Punct {
-                                        char: '=',
+                                        char: '|',
                                         spacing: Alone,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
+                                        span: bytes(52..53),
                                     },
                                     Ident {
-                                        sym: leptos,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos_dom,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: html,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: button,
-                                        span: bytes(76..82),
-                                    },
-                                    Punct {
-                                        char: ';',
-                                        spacing: Alone,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos_dom,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: html,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: button,
-                                        span: bytes(29..35),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [],
-                                    },
-                                    Punct {
-                                        char: '.',
-                                        spacing: Alone,
-                                        span: bytes(36..38),
-                                    },
-                                    Ident {
-                                        sym: on,
-                                        span: bytes(36..38),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: leptos,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: ev,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: click,
-                                                span: bytes(39..44),
-                                            },
-                                            Punct {
-                                                char: ',',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: move,
-                                                span: bytes(45..49),
-                                            },
-                                            Punct {
-                                                char: '|',
-                                                spacing: Alone,
-                                                span: bytes(50..51),
-                                            },
-                                            Ident {
-                                                sym: _,
-                                                span: bytes(51..52),
-                                            },
-                                            Punct {
-                                                char: '|',
-                                                spacing: Alone,
-                                                span: bytes(52..53),
-                                            },
-                                            Ident {
-                                                sym: set_value,
-                                                span: bytes(54..63),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Literal {
-                                                        lit: 0,
-                                                        span: bytes(64..65),
-                                                    },
-                                                ],
-                                                span: bytes(63..66),
-                                            },
-                                        ],
-                                    },
-                                    Punct {
-                                        char: '.',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: child,
+                                        sym: set_value,
+                                        span: bytes(54..63),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Literal {
-                                                lit: "Clear",
-                                                span: bytes(67..74),
+                                                lit: 0,
+                                                span: bytes(64..65),
                                             },
                                         ],
+                                        span: bytes(63..66),
+                                    },
+                                ],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: child,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Literal {
+                                        lit: "Clear",
+                                        span: bytes(67..74),
                                     },
                                 ],
                             },
                         ],
+                        span: bytes(28..83),
                     },
                 ],
             },
@@ -354,265 +401,286 @@ TokenStream [
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
+                    Punct {
+                        char: '#',
+                        spacing: Alone,
+                        span: bytes(96..176),
+                    },
                     Group {
-                        delimiter: Parenthesis,
+                        delimiter: Bracket,
                         stream: TokenStream [
+                            Ident {
+                                sym: allow,
+                                span: bytes(96..176),
+                            },
                             Group {
-                                delimiter: Brace,
+                                delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
-                                        sym: let,
+                                        sym: unused_braces,
+                                        span: bytes(96..176),
+                                    },
+                                ],
+                                span: bytes(96..176),
+                            },
+                        ],
+                        span: bytes(96..176),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Ident {
+                                sym: let,
+                            },
+                            Ident {
+                                sym: _,
+                            },
+                            Punct {
+                                char: '=',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos_dom,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: html,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: button,
+                                span: bytes(169..175),
+                            },
+                            Punct {
+                                char: ';',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos_dom,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: html,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: button,
+                                span: bytes(97..103),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                                span: bytes(104..106),
+                            },
+                            Ident {
+                                sym: on,
+                                span: bytes(104..106),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: leptos,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: ev,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: click,
+                                        span: bytes(107..112),
+                                    },
+                                    Punct {
+                                        char: ',',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: move,
+                                        span: bytes(113..117),
+                                    },
+                                    Punct {
+                                        char: '|',
+                                        spacing: Alone,
+                                        span: bytes(118..119),
                                     },
                                     Ident {
                                         sym: _,
+                                        span: bytes(119..120),
                                     },
                                     Punct {
-                                        char: '=',
+                                        char: '|',
                                         spacing: Alone,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
+                                        span: bytes(120..121),
                                     },
                                     Ident {
-                                        sym: leptos,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos_dom,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: html,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: button,
-                                        span: bytes(169..175),
-                                    },
-                                    Punct {
-                                        char: ';',
-                                        spacing: Alone,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos_dom,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: html,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: button,
-                                        span: bytes(97..103),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [],
+                                        sym: set_value,
+                                        span: bytes(122..131),
                                     },
                                     Punct {
                                         char: '.',
                                         spacing: Alone,
-                                        span: bytes(104..106),
+                                        span: bytes(131..132),
                                     },
                                     Ident {
-                                        sym: on,
-                                        span: bytes(104..106),
+                                        sym: update,
+                                        span: bytes(132..138),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
+                                                char: '|',
                                                 spacing: Alone,
+                                                span: bytes(139..140),
                                             },
                                             Ident {
-                                                sym: leptos,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: ev,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: click,
-                                                span: bytes(107..112),
-                                            },
-                                            Punct {
-                                                char: ',',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: move,
-                                                span: bytes(113..117),
+                                                sym: value,
+                                                span: bytes(140..145),
                                             },
                                             Punct {
                                                 char: '|',
                                                 spacing: Alone,
-                                                span: bytes(118..119),
-                                            },
-                                            Ident {
-                                                sym: _,
-                                                span: bytes(119..120),
+                                                span: bytes(145..146),
                                             },
                                             Punct {
-                                                char: '|',
+                                                char: '*',
                                                 spacing: Alone,
-                                                span: bytes(120..121),
+                                                span: bytes(147..148),
                                             },
                                             Ident {
-                                                sym: set_value,
-                                                span: bytes(122..131),
+                                                sym: value,
+                                                span: bytes(148..153),
                                             },
                                             Punct {
-                                                char: '.',
+                                                char: '-',
+                                                spacing: Joint,
+                                                span: bytes(154..155),
+                                            },
+                                            Punct {
+                                                char: '=',
                                                 spacing: Alone,
-                                                span: bytes(131..132),
+                                                span: bytes(155..156),
                                             },
                                             Ident {
-                                                sym: update,
-                                                span: bytes(132..138),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Punct {
-                                                        char: '|',
-                                                        spacing: Alone,
-                                                        span: bytes(139..140),
-                                                    },
-                                                    Ident {
-                                                        sym: value,
-                                                        span: bytes(140..145),
-                                                    },
-                                                    Punct {
-                                                        char: '|',
-                                                        spacing: Alone,
-                                                        span: bytes(145..146),
-                                                    },
-                                                    Punct {
-                                                        char: '*',
-                                                        spacing: Alone,
-                                                        span: bytes(147..148),
-                                                    },
-                                                    Ident {
-                                                        sym: value,
-                                                        span: bytes(148..153),
-                                                    },
-                                                    Punct {
-                                                        char: '-',
-                                                        spacing: Joint,
-                                                        span: bytes(154..155),
-                                                    },
-                                                    Punct {
-                                                        char: '=',
-                                                        spacing: Alone,
-                                                        span: bytes(155..156),
-                                                    },
-                                                    Ident {
-                                                        sym: step,
-                                                        span: bytes(157..161),
-                                                    },
-                                                ],
-                                                span: bytes(138..162),
+                                                sym: step,
+                                                span: bytes(157..161),
                                             },
                                         ],
+                                        span: bytes(138..162),
                                     },
-                                    Punct {
-                                        char: '.',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: child,
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Literal {
-                                                lit: "-1",
-                                                span: bytes(163..167),
-                                            },
-                                        ],
+                                ],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: child,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Literal {
+                                        lit: "-1",
+                                        span: bytes(163..167),
                                     },
                                 ],
                             },
                         ],
+                        span: bytes(96..176),
                     },
                 ],
             },
@@ -626,182 +694,198 @@ TokenStream [
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
+                    Punct {
+                        char: '#',
+                        spacing: Alone,
+                        span: bytes(189..223),
+                    },
                     Group {
-                        delimiter: Parenthesis,
+                        delimiter: Bracket,
                         stream: TokenStream [
+                            Ident {
+                                sym: allow,
+                                span: bytes(189..223),
+                            },
                             Group {
-                                delimiter: Brace,
+                                delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
-                                        sym: let,
+                                        sym: unused_braces,
+                                        span: bytes(189..223),
                                     },
-                                    Ident {
-                                        sym: _,
+                                ],
+                                span: bytes(189..223),
+                            },
+                        ],
+                        span: bytes(189..223),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Ident {
+                                sym: let,
+                            },
+                            Ident {
+                                sym: _,
+                            },
+                            Punct {
+                                char: '=',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos_dom,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: html,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: span,
+                                span: bytes(218..222),
+                            },
+                            Punct {
+                                char: ';',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos_dom,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: html,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: span,
+                                span: bytes(190..194),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: child,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Literal {
+                                        lit: "Value: ",
+                                        span: bytes(195..204),
                                     },
-                                    Punct {
-                                        char: '=',
-                                        spacing: Alone,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos_dom,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: html,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: span,
-                                        span: bytes(218..222),
-                                    },
-                                    Punct {
-                                        char: ';',
-                                        spacing: Alone,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos_dom,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: html,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: span,
-                                        span: bytes(190..194),
-                                    },
+                                ],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: child,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
                                     Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [],
-                                    },
-                                    Punct {
-                                        char: '.',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: child,
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
+                                        delimiter: Brace,
                                         stream: TokenStream [
-                                            Literal {
-                                                lit: "Value: ",
-                                                span: bytes(195..204),
+                                            Ident {
+                                                sym: value,
+                                                span: bytes(206..211),
                                             },
                                         ],
+                                        span: bytes(205..212),
                                     },
-                                    Punct {
-                                        char: '.',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: child,
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Group {
-                                                        delimiter: Brace,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                sym: value,
-                                                                span: bytes(206..211),
-                                                            },
-                                                        ],
-                                                        span: bytes(205..212),
-                                                    },
-                                                ],
-                                            },
-                                        ],
-                                    },
-                                    Punct {
-                                        char: '.',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: child,
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Literal {
-                                                lit: "!",
-                                                span: bytes(213..216),
-                                            },
-                                        ],
+                                ],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: child,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Literal {
+                                        lit: "!",
+                                        span: bytes(213..216),
                                     },
                                 ],
                             },
                         ],
+                        span: bytes(189..223),
                     },
                 ],
             },
@@ -815,268 +899,290 @@ TokenStream [
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
+                    Punct {
+                        char: '#',
+                        spacing: Alone,
+                        span: bytes(236..316),
+                    },
                     Group {
-                        delimiter: Parenthesis,
+                        delimiter: Bracket,
                         stream: TokenStream [
+                            Ident {
+                                sym: allow,
+                                span: bytes(236..316),
+                            },
                             Group {
-                                delimiter: Brace,
+                                delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
-                                        sym: let,
+                                        sym: unused_braces,
+                                        span: bytes(236..316),
+                                    },
+                                ],
+                                span: bytes(236..316),
+                            },
+                        ],
+                        span: bytes(236..316),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Ident {
+                                sym: let,
+                            },
+                            Ident {
+                                sym: _,
+                            },
+                            Punct {
+                                char: '=',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos_dom,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: html,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: button,
+                                span: bytes(309..315),
+                            },
+                            Punct {
+                                char: ';',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos_dom,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: html,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: button,
+                                span: bytes(237..243),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                                span: bytes(244..246),
+                            },
+                            Ident {
+                                sym: on,
+                                span: bytes(244..246),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: leptos,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: ev,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: click,
+                                        span: bytes(247..252),
+                                    },
+                                    Punct {
+                                        char: ',',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: move,
+                                        span: bytes(253..257),
+                                    },
+                                    Punct {
+                                        char: '|',
+                                        spacing: Alone,
+                                        span: bytes(258..259),
                                     },
                                     Ident {
                                         sym: _,
+                                        span: bytes(259..260),
                                     },
                                     Punct {
-                                        char: '=',
+                                        char: '|',
                                         spacing: Alone,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
+                                        span: bytes(260..261),
                                     },
                                     Ident {
-                                        sym: leptos,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos_dom,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: html,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: button,
-                                        span: bytes(309..315),
-                                    },
-                                    Punct {
-                                        char: ';',
-                                        spacing: Alone,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: leptos_dom,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: html,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Joint,
-                                    },
-                                    Punct {
-                                        char: ':',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: button,
-                                        span: bytes(237..243),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [],
+                                        sym: set_value,
+                                        span: bytes(262..271),
                                     },
                                     Punct {
                                         char: '.',
                                         spacing: Alone,
-                                        span: bytes(244..246),
+                                        span: bytes(271..272),
                                     },
                                     Ident {
-                                        sym: on,
-                                        span: bytes(244..246),
+                                        sym: update,
+                                        span: bytes(272..278),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
+                                                char: '|',
                                                 spacing: Alone,
+                                                span: bytes(279..280),
                                             },
                                             Ident {
-                                                sym: leptos,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: ev,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Joint,
-                                            },
-                                            Punct {
-                                                char: ':',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: click,
-                                                span: bytes(247..252),
-                                            },
-                                            Punct {
-                                                char: ',',
-                                                spacing: Alone,
-                                            },
-                                            Ident {
-                                                sym: move,
-                                                span: bytes(253..257),
+                                                sym: value,
+                                                span: bytes(280..285),
                                             },
                                             Punct {
                                                 char: '|',
                                                 spacing: Alone,
-                                                span: bytes(258..259),
-                                            },
-                                            Ident {
-                                                sym: _,
-                                                span: bytes(259..260),
+                                                span: bytes(285..286),
                                             },
                                             Punct {
-                                                char: '|',
+                                                char: '*',
                                                 spacing: Alone,
-                                                span: bytes(260..261),
+                                                span: bytes(287..288),
                                             },
                                             Ident {
-                                                sym: set_value,
-                                                span: bytes(262..271),
+                                                sym: value,
+                                                span: bytes(288..293),
                                             },
                                             Punct {
-                                                char: '.',
+                                                char: '+',
+                                                spacing: Joint,
+                                                span: bytes(294..295),
+                                            },
+                                            Punct {
+                                                char: '=',
                                                 spacing: Alone,
-                                                span: bytes(271..272),
+                                                span: bytes(295..296),
                                             },
                                             Ident {
-                                                sym: update,
-                                                span: bytes(272..278),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Punct {
-                                                        char: '|',
-                                                        spacing: Alone,
-                                                        span: bytes(279..280),
-                                                    },
-                                                    Ident {
-                                                        sym: value,
-                                                        span: bytes(280..285),
-                                                    },
-                                                    Punct {
-                                                        char: '|',
-                                                        spacing: Alone,
-                                                        span: bytes(285..286),
-                                                    },
-                                                    Punct {
-                                                        char: '*',
-                                                        spacing: Alone,
-                                                        span: bytes(287..288),
-                                                    },
-                                                    Ident {
-                                                        sym: value,
-                                                        span: bytes(288..293),
-                                                    },
-                                                    Punct {
-                                                        char: '+',
-                                                        spacing: Joint,
-                                                        span: bytes(294..295),
-                                                    },
-                                                    Punct {
-                                                        char: '=',
-                                                        spacing: Alone,
-                                                        span: bytes(295..296),
-                                                    },
-                                                    Ident {
-                                                        sym: step,
-                                                        span: bytes(297..301),
-                                                    },
-                                                ],
-                                                span: bytes(278..302),
+                                                sym: step,
+                                                span: bytes(297..301),
                                             },
                                         ],
+                                        span: bytes(278..302),
                                     },
-                                    Punct {
-                                        char: '.',
-                                        spacing: Alone,
-                                    },
-                                    Ident {
-                                        sym: child,
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Literal {
-                                                lit: "+1",
-                                                span: bytes(303..307),
-                                            },
-                                        ],
+                                ],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: child,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Literal {
+                                        lit: "+1",
+                                        span: bytes(303..307),
                                     },
                                 ],
                             },
                         ],
+                        span: bytes(236..316),
                     },
                 ],
             },
         ],
+        span: bytes(10..331),
     },
 ]

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__simple_counter.snap
@@ -1,21 +1,25 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
+    #[allow(unused_braces)]
     {
         let _ = ::leptos::leptos_dom::html::div;
         ::leptos::leptos_dom::html::div()
             .child(
-                ({
+                #[allow(unused_braces)]
+                {
                     let _ = ::leptos::leptos_dom::html::button;
                     ::leptos::leptos_dom::html::button()
                         .on(::leptos::ev::click, move |_| set_value(0))
                         .child("Clear")
-                }),
+                },
             )
             .child(
-                ({
+                #[allow(unused_braces)]
+                {
                     let _ = ::leptos::leptos_dom::html::button;
                     ::leptos::leptos_dom::html::button()
                         .on(
@@ -23,19 +27,21 @@ fn view() {
                             move |_| set_value.update(|value| *value -= step),
                         )
                         .child("-1")
-                }),
+                },
             )
             .child(
-                ({
+                #[allow(unused_braces)]
+                {
                     let _ = ::leptos::leptos_dom::html::span;
                     ::leptos::leptos_dom::html::span()
                         .child("Value: ")
-                        .child(({ value }))
+                        .child({ value })
                         .child("!")
-                }),
+                },
             )
             .child(
-                ({
+                #[allow(unused_braces)]
+                {
                     let _ = ::leptos::leptos_dom::html::button;
                     ::leptos::leptos_dom::html::button()
                         .on(
@@ -43,7 +49,7 @@ fn view() {
                             move |_| set_value.update(|value| *value += step),
                         )
                         .child("+1")
-                }),
+                },
             )
     }
 }

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__counter_component.snap
@@ -1,14 +1,15 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
-    ::leptos::component_view(
-        &SimpleCounter,
-        ::leptos::component_props_builder(&SimpleCounter)
+    {
+        let props = ::leptos::component_props_builder(&SimpleCounter)
             .initial_value(#[allow(unused_braces)] { 0 })
             .step(#[allow(unused_braces)] { 1 })
-            .build(),
-    )
+            .build();
+        #[allow(unreachable_code)] ::leptos::component_view(&SimpleCounter, props)
+    }
 }
 

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__custom_event.snap
@@ -1,15 +1,18 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
     ::leptos::IntoView::into_view(
             #[allow(unused_braces)]
             {
-                ::leptos::component_view(
-                    &ExternalComponent,
-                    ::leptos::component_props_builder(&ExternalComponent).build(),
-                )
+                {
+                    let props = ::leptos::component_props_builder(&ExternalComponent)
+                        .build();
+                    #[allow(unreachable_code)]
+                    ::leptos::component_view(&ExternalComponent, props)
+                }
             },
         )
         .on(

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__counter_component.snap
@@ -1,66 +1,52 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: result
 ---
 TokenStream [
-    Punct {
-        char: ':',
-        spacing: Joint,
-    },
-    Punct {
-        char: ':',
-        spacing: Alone,
-    },
-    Ident {
-        sym: leptos,
-    },
-    Punct {
-        char: ':',
-        spacing: Joint,
-    },
-    Punct {
-        char: ':',
-        spacing: Alone,
-    },
-    Ident {
-        sym: component_view,
-    },
     Group {
-        delimiter: Parenthesis,
+        delimiter: Brace,
         stream: TokenStream [
-            Punct {
-                char: '&',
-                spacing: Alone,
+            Ident {
+                sym: let,
+                span: bytes(10..82),
             },
             Ident {
-                sym: SimpleCounter,
+                sym: props,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: '=',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
                 span: bytes(11..24),
             },
             Punct {
-                char: ',',
-                spacing: Alone,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
                 char: ':',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: leptos,
+                span: bytes(11..24),
             },
             Punct {
                 char: ':',
                 spacing: Joint,
+                span: bytes(11..24),
             },
             Punct {
                 char: ':',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: component_props_builder,
+                span: bytes(11..24),
             },
             Group {
                 delimiter: Parenthesis,
@@ -68,16 +54,19 @@ TokenStream [
                     Punct {
                         char: '&',
                         spacing: Alone,
+                        span: bytes(11..24),
                     },
                     Ident {
                         sym: SimpleCounter,
                         span: bytes(11..24),
                     },
                 ],
+                span: bytes(11..24),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(37..52),
             },
             Ident {
                 sym: initial_value,
@@ -89,22 +78,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
+                        span: bytes(51..52),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
+                                span: bytes(51..52),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
+                                        span: bytes(51..52),
                                     },
                                 ],
+                                span: bytes(51..52),
                             },
                         ],
+                        span: bytes(51..52),
                     },
                     Group {
                         delimiter: Brace,
@@ -114,12 +108,15 @@ TokenStream [
                                 span: bytes(51..52),
                             },
                         ],
+                        span: bytes(51..52),
                     },
                 ],
+                span: bytes(37..52),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(65..71),
             },
             Ident {
                 sym: step,
@@ -131,22 +128,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
+                        span: bytes(70..71),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
+                                span: bytes(70..71),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
+                                        span: bytes(70..71),
                                     },
                                 ],
+                                span: bytes(70..71),
                             },
                         ],
+                        span: bytes(70..71),
                     },
                     Group {
                         delimiter: Brace,
@@ -156,20 +158,108 @@ TokenStream [
                                 span: bytes(70..71),
                             },
                         ],
+                        span: bytes(70..71),
                     },
                 ],
+                span: bytes(65..71),
             },
             Punct {
                 char: '.',
                 spacing: Alone,
+                span: bytes(11..24),
             },
             Ident {
                 sym: build,
+                span: bytes(11..24),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [],
+                span: bytes(11..24),
+            },
+            Punct {
+                char: ';',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: '#',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        sym: allow,
+                        span: bytes(10..82),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                sym: unreachable_code,
+                                span: bytes(10..82),
+                            },
+                        ],
+                        span: bytes(10..82),
+                    },
+                ],
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Ident {
+                sym: leptos,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+                span: bytes(10..82),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(10..82),
+            },
+            Ident {
+                sym: component_view,
+                span: bytes(10..82),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: '&',
+                        spacing: Alone,
+                        span: bytes(11..24),
+                    },
+                    Ident {
+                        sym: SimpleCounter,
+                        span: bytes(11..24),
+                    },
+                    Punct {
+                        char: ',',
+                        spacing: Alone,
+                        span: bytes(10..82),
+                    },
+                    Ident {
+                        sym: props,
+                        span: bytes(10..82),
+                    },
+                ],
+                span: bytes(10..82),
             },
         ],
+        span: bytes(10..82),
     },
 ]

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__custom_event.snap
@@ -1,40 +1,50 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: result
 ---
 TokenStream [
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: leptos,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: IntoView,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Joint,
+        span: bytes(10..82),
     },
     Punct {
         char: ':',
         spacing: Alone,
+        span: bytes(10..82),
     },
     Ident {
         sym: into_view,
+        span: bytes(10..82),
     },
     Group {
         delimiter: Parenthesis,
@@ -42,84 +52,74 @@ TokenStream [
             Punct {
                 char: '#',
                 spacing: Alone,
+                span: bytes(10..82),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         sym: allow,
+                        span: bytes(10..82),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 sym: unused_braces,
+                                span: bytes(10..82),
                             },
                         ],
+                        span: bytes(10..82),
                     },
                 ],
+                span: bytes(10..82),
             },
             Group {
                 delimiter: Brace,
                 stream: TokenStream [
-                    Punct {
-                        char: ':',
-                        spacing: Joint,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: leptos,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Joint,
-                    },
-                    Punct {
-                        char: ':',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: component_view,
-                    },
                     Group {
-                        delimiter: Parenthesis,
+                        delimiter: Brace,
                         stream: TokenStream [
-                            Punct {
-                                char: '&',
-                                spacing: Alone,
+                            Ident {
+                                sym: let,
+                                span: bytes(10..82),
                             },
                             Ident {
-                                sym: ExternalComponent,
+                                sym: props,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: '=',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
                                 span: bytes(11..28),
                             },
                             Punct {
-                                char: ',',
-                                spacing: Alone,
-                            },
-                            Punct {
-                                char: ':',
-                                spacing: Joint,
-                            },
-                            Punct {
                                 char: ':',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: leptos,
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: ':',
                                 spacing: Joint,
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: ':',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: component_props_builder,
+                                span: bytes(11..28),
                             },
                             Group {
                                 delimiter: Parenthesis,
@@ -127,29 +127,119 @@ TokenStream [
                                     Punct {
                                         char: '&',
                                         spacing: Alone,
+                                        span: bytes(11..28),
                                     },
                                     Ident {
                                         sym: ExternalComponent,
                                         span: bytes(11..28),
                                     },
                                 ],
+                                span: bytes(11..28),
                             },
                             Punct {
                                 char: '.',
                                 spacing: Alone,
+                                span: bytes(11..28),
                             },
                             Ident {
                                 sym: build,
+                                span: bytes(11..28),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [],
+                                span: bytes(11..28),
+                            },
+                            Punct {
+                                char: ';',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: '#',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        sym: allow,
+                                        span: bytes(10..82),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                sym: unreachable_code,
+                                                span: bytes(10..82),
+                                            },
+                                        ],
+                                        span: bytes(10..82),
+                                    },
+                                ],
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Ident {
+                                sym: leptos,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                                span: bytes(10..82),
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                                span: bytes(10..82),
+                            },
+                            Ident {
+                                sym: component_view,
+                                span: bytes(10..82),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: '&',
+                                        spacing: Alone,
+                                        span: bytes(11..28),
+                                    },
+                                    Ident {
+                                        sym: ExternalComponent,
+                                        span: bytes(11..28),
+                                    },
+                                    Punct {
+                                        char: ',',
+                                        spacing: Alone,
+                                        span: bytes(10..82),
+                                    },
+                                    Ident {
+                                        sym: props,
+                                        span: bytes(10..82),
+                                    },
+                                ],
+                                span: bytes(10..82),
                             },
                         ],
+                        span: bytes(10..82),
                     },
                 ],
+                span: bytes(10..82),
             },
         ],
+        span: bytes(10..82),
     },
     Punct {
         char: '.',
@@ -157,6 +247,7 @@ TokenStream [
     },
     Ident {
         sym: on,
+        span: bytes(29..50),
     },
     Group {
         delimiter: Parenthesis,

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__simple_counter.snap
@@ -1,5 +1,6 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: result
 ---
 TokenStream [
@@ -1877,40 +1878,15 @@ TokenStream [
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
-                                            Punct {
-                                                char: '#',
-                                                spacing: Alone,
-                                            },
-                                            Group {
-                                                delimiter: Bracket,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        sym: allow,
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                sym: unused_braces,
-                                                            },
-                                                        ],
-                                                    },
-                                                ],
-                                            },
                                             Group {
                                                 delimiter: Brace,
                                                 stream: TokenStream [
-                                                    Group {
-                                                        delimiter: Brace,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                sym: value,
-                                                                span: bytes(206..211),
-                                                            },
-                                                        ],
-                                                        span: bytes(205..212),
+                                                    Ident {
+                                                        sym: value,
+                                                        span: bytes(206..211),
                                                     },
                                                 ],
+                                                span: bytes(205..212),
                                             },
                                         ],
                                     },

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__simple_counter.snap
@@ -1,5 +1,6 @@
 ---
 source: leptos_macro/src/view/tests.rs
+assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
@@ -46,10 +47,7 @@ fn view() {
                 ),
                 #[allow(unused_braces)]
                 {
-                    let view = ::leptos::IntoView::into_view(
-                        #[allow(unused_braces)]
-                        { { value } },
-                    );
+                    let view = ::leptos::IntoView::into_view({ value });
                     ::leptos::leptos_dom::html::StringOrView::View(
                         ::std::rc::Rc::new(move || view.clone()),
                     )

--- a/leptos_macro/tests/ui.rs
+++ b/leptos_macro/tests/ui.rs
@@ -4,4 +4,5 @@ fn ui() {
     t.compile_fail("tests/ui/component.rs");
     t.compile_fail("tests/ui/component_absolute.rs");
     t.compile_fail("tests/ui/server.rs");
+    t.compile_fail("tests/ui/view/*.rs");
 }

--- a/leptos_macro/tests/ui/view/block_in_fragment.rs
+++ b/leptos_macro/tests/ui/view/block_in_fragment.rs
@@ -1,0 +1,9 @@
+use leptos::*;
+
+struct A;
+
+fn main() {
+    view! {
+        <>{A}</>
+    };
+}

--- a/leptos_macro/tests/ui/view/block_in_fragment.stderr
+++ b/leptos_macro/tests/ui/view/block_in_fragment.stderr
@@ -1,0 +1,29 @@
+error[E0277]: expected a `Fn()` closure, found `A`
+ --> tests/ui/view/block_in_fragment.rs:7:11
+  |
+6 | /     view! {
+7 | |         <>{A}</>
+  | |           ^-^
+  | |           ||
+  | |           |this tail expression is of type `A`
+  | |           expected an `Fn()` closure, found `A`
+8 | |     };
+  | |_____- required by a bound introduced by this call
+  |
+  = help: the trait `std::ops::Fn<()>` is not implemented for `A`
+  = note: wrap the `A` in a closure with no arguments: `|| { /* code */ }`
+  = help: the following other types implement trait `IntoView`:
+            bool
+            char
+            isize
+            i8
+            i16
+            i32
+            i64
+            i128
+          and $N others
+  = note: required for `A` to implement `IntoView`
+help: you might have meant to create the closure instead of a block
+  |
+7 |         <>|_| {A}</>
+  |           +++

--- a/leptos_macro/tests/ui/view/children_clone.rs
+++ b/leptos_macro/tests/ui/view/children_clone.rs
@@ -1,0 +1,36 @@
+use leptos::*;
+
+#[slot]
+struct Then {
+    children: Children,
+}
+
+#[component]
+fn Component(children: Children) -> impl IntoView {
+    _ = children;
+}
+
+#[component]
+fn Slot(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+struct A;
+
+fn main() {
+    let a = A;
+
+    view! {
+        <Component clone:a>
+            <p />
+        </Component>
+    };
+
+    view! {
+        <Slot>
+            <Then slot clone:a>
+                <p/>
+            </Then>
+        </Slot>
+    };
+}

--- a/leptos_macro/tests/ui/view/children_clone.stderr
+++ b/leptos_macro/tests/ui/view/children_clone.stderr
@@ -1,0 +1,35 @@
+error[E0277]: the trait bound `A: Clone` is not satisfied
+  --> tests/ui/view/children_clone.rs:24:20
+   |
+23 | /     view! {
+24 | |         <Component clone:a>
+   | |                    ^^^^^^^ the trait `Clone` is not implemented for `A`
+25 | |             <p />
+26 | |         </Component>
+27 | |     };
+   | |_____- required by a bound introduced by this call
+   |
+help: consider annotating `A` with `#[derive(Clone)]`
+   |
+18 + #[derive(Clone)]
+19 | struct A;
+   |
+
+error[E0277]: the trait bound `A: Clone` is not satisfied
+  --> tests/ui/view/children_clone.rs:31:24
+   |
+29 | /     view! {
+30 | |         <Slot>
+31 | |             <Then slot clone:a>
+   | |                        ^^^^^^^ the trait `Clone` is not implemented for `A`
+32 | |                 <p/>
+33 | |             </Then>
+34 | |         </Slot>
+35 | |     };
+   | |_____- required by a bound introduced by this call
+   |
+help: consider annotating `A` with `#[derive(Clone)]`
+   |
+18 + #[derive(Clone)]
+19 | struct A;
+   |

--- a/leptos_macro/tests/ui/view/children_projection_error.rs
+++ b/leptos_macro/tests/ui/view/children_projection_error.rs
@@ -1,0 +1,28 @@
+use leptos::*;
+
+#[component]
+fn Outer(children: ChildrenFn) -> impl IntoView {
+    _ = children;
+}
+
+#[component]
+fn Inner(children: ChildrenFn) -> impl IntoView {
+    _ = children;
+}
+
+#[component]
+fn Inmost(name: String) -> impl IntoView {
+    _ = name;
+}
+
+fn main() {
+    let name = "Alice".to_string();
+
+    view! {
+        <Outer>
+            <Inner>
+                <Inmost name=name.clone()/>
+            </Inner>
+        </Outer>
+    };
+}

--- a/leptos_macro/tests/ui/view/children_projection_error.stderr
+++ b/leptos_macro/tests/ui/view/children_projection_error.stderr
@@ -1,0 +1,13 @@
+error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnOnce`
+  --> tests/ui/view/children_projection_error.rs:23:13
+   |
+23 | /             <Inner>
+24 | |                 <Inmost name=name.clone()/>
+   | |                              ---- closure is `FnOnce` because it moves the variable `name` out of its environment
+25 | |             </Inner>
+   | |                    ^
+   | |                    |
+   | |____________________this closure implements `FnOnce`, not `Fn`
+   |                      the requirement to implement `Fn` derives from here
+   |
+   = note: required for `Rc<dyn std::ops::Fn() -> Fragment>` to implement `ToChildren<{closure@$DIR/tests/ui/view/children_projection_error.rs:23:13: 25:21}>`

--- a/leptos_macro/tests/ui/view/children_projection_error_slot_version.rs
+++ b/leptos_macro/tests/ui/view/children_projection_error_slot_version.rs
@@ -1,0 +1,35 @@
+use leptos::*;
+
+#[component]
+fn Root(outer: Outer) -> impl IntoView {
+    _ = outer;
+}
+
+#[slot]
+struct Outer {
+    children: ChildrenFn,
+}
+
+#[component]
+fn Inner(children: ChildrenFn) -> impl IntoView {
+    _ = children;
+}
+
+#[component]
+fn Inmost(name: String) -> impl IntoView {
+    _ = name;
+}
+
+fn main() {
+    let name = "Alice".to_string();
+
+    view! {
+        <Root>
+            <Outer slot>
+                <Inner>
+                    <Inmost name=name.clone() />
+                </Inner>
+            </Outer>
+        </Root>
+    };
+}

--- a/leptos_macro/tests/ui/view/children_projection_error_slot_version.stderr
+++ b/leptos_macro/tests/ui/view/children_projection_error_slot_version.stderr
@@ -1,0 +1,13 @@
+error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnOnce`
+  --> tests/ui/view/children_projection_error_slot_version.rs:29:17
+   |
+29 | /                 <Inner>
+30 | |                     <Inmost name=name.clone() />
+   | |                                  ---- closure is `FnOnce` because it moves the variable `name` out of its environment
+31 | |                 </Inner>
+   | |                        ^
+   | |                        |
+   | |________________________this closure implements `FnOnce`, not `Fn`
+   |                          the requirement to implement `Fn` derives from here
+   |
+   = note: required for `Rc<dyn std::ops::Fn() -> Fragment>` to implement `ToChildren<{closure@$DIR/tests/ui/view/children_projection_error_slot_version.rs:29:17: 31:25}>`

--- a/leptos_macro/tests/ui/view/component_with_props_without_macro.rs
+++ b/leptos_macro/tests/ui/view/component_with_props_without_macro.rs
@@ -1,0 +1,12 @@
+use leptos::*;
+
+#[allow(unused, non_snake_case)]
+fn Component(prop: i32) -> impl IntoView {
+    _ = prop;
+}
+
+fn main() {
+    view! {
+        <Component />
+    };
+}

--- a/leptos_macro/tests/ui/view/component_with_props_without_macro.stderr
+++ b/leptos_macro/tests/ui/view/component_with_props_without_macro.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `fn(i32) -> impl leptos::IntoView {Component}: leptos::Component<_>` is not satisfied
+  --> tests/ui/view/component_with_props_without_macro.rs:10:10
+   |
+10 |         <Component />
+   |          ^^^^^^^^^ the trait `leptos::Component<_>` is not implemented for fn item `fn(i32) -> impl leptos::IntoView {Component}`
+   |
+note: required by a bound in `component_props_builder`
+  --> $WORKSPACE/leptos/src/lib.rs
+   |
+   | pub fn component_props_builder<P: PropsOrNoPropsBuilder>(
+   |        ----------------------- required by a bound in this function
+   |     _f: &impl Component<P>,
+   |               ^^^^^^^^^^^^ required by this bound in `component_props_builder`
+
+error[E0277]: the trait bound `&fn(i32) -> impl leptos::IntoView {Component}: ComponentConstructor<_>` is not satisfied
+  --> tests/ui/view/component_with_props_without_macro.rs:10:10
+   |
+10 |         <Component />
+   |         -^^^^^^^^^---
+   |         ||
+   |         |the trait `ComponentConstructor<_>` is not implemented for `&fn(i32) -> impl leptos::IntoView {Component}`
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `component_view`
+  --> $WORKSPACE/leptos/src/lib.rs
+   |
+   | pub fn component_view<P>(f: impl ComponentConstructor<P>, props: P) -> View {
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `component_view`

--- a/leptos_macro/tests/ui/view/directives.rs
+++ b/leptos_macro/tests/ui/view/directives.rs
@@ -1,0 +1,23 @@
+use leptos::*;
+
+#[component]
+fn Component() -> impl IntoView {}
+fn highlight(el: HtmlElement<html::AnyElement>, prop: i32) {
+    _ = prop;
+}
+
+fn main() {
+    let data = "Hello World!";
+
+    view! {
+        <Component use:highlight />
+    };
+
+    view! {
+        <Component use:highlight="asd" />
+    };
+
+    view! {
+        <Component use:highlight=data />
+    };
+}

--- a/leptos_macro/tests/ui/view/directives.stderr
+++ b/leptos_macro/tests/ui/view/directives.stderr
@@ -1,0 +1,50 @@
+error[E0277]: the trait bound `i32: From<()>` is not satisfied
+  --> tests/ui/view/directives.rs:13:20
+   |
+13 |         <Component use:highlight />
+   |                    ^^^^^^^^^^^^^ the trait `From<()>` is not implemented for `i32`
+   |
+   = help: the following other types implement trait `From<T>`:
+             <i32 as From<bool>>
+             <i32 as From<i8>>
+             <i32 as From<i16>>
+             <i32 as From<u8>>
+             <i32 as From<u16>>
+             <i32 as From<NonZeroI32>>
+   = note: required for `()` to implement `Into<i32>`
+
+error[E0277]: the trait bound `i32: From<&str>` is not satisfied
+  --> tests/ui/view/directives.rs:17:34
+   |
+16 | /     view! {
+17 | |         <Component use:highlight="asd" />
+   | |                                  ^^^^^ the trait `From<&str>` is not implemented for `i32`
+18 | |     };
+   | |_____- required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `From<T>`:
+             <i32 as From<bool>>
+             <i32 as From<i8>>
+             <i32 as From<i16>>
+             <i32 as From<u8>>
+             <i32 as From<u16>>
+             <i32 as From<NonZeroI32>>
+   = note: required for `&str` to implement `Into<i32>`
+
+error[E0277]: the trait bound `i32: From<&str>` is not satisfied
+  --> tests/ui/view/directives.rs:21:34
+   |
+20 | /     view! {
+21 | |         <Component use:highlight=data />
+   | |                                  ^^^^ the trait `From<&str>` is not implemented for `i32`
+22 | |     };
+   | |_____- required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `From<T>`:
+             <i32 as From<bool>>
+             <i32 as From<i8>>
+             <i32 as From<i16>>
+             <i32 as From<u8>>
+             <i32 as From<u16>>
+             <i32 as From<NonZeroI32>>
+   = note: required for `&str` to implement `Into<i32>`

--- a/leptos_macro/tests/ui/view/events.rs
+++ b/leptos_macro/tests/ui/view/events.rs
@@ -1,0 +1,10 @@
+use leptos::*;
+
+#[component]
+fn Component() -> impl IntoView {}
+
+fn main() {
+    view! {
+        <Component on:click=|| {} />
+    };
+}

--- a/leptos_macro/tests/ui/view/events.stderr
+++ b/leptos_macro/tests/ui/view/events.stderr
@@ -1,0 +1,12 @@
+error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
+ --> tests/ui/view/events.rs:8:20
+  |
+8 |         <Component on:click=|| {} />
+  |                    ^^^^^^^^ -- takes 0 arguments
+  |                    |
+  |                    expected closure that takes 1 argument
+  |
+help: consider changing the closure to take and ignore the expected argument
+  |
+8 |         <Component on:click=|_| {} />
+  |                             ~~~

--- a/leptos_macro/tests/ui/view/expected_children_got_let_bind.rs
+++ b/leptos_macro/tests/ui/view/expected_children_got_let_bind.rs
@@ -1,0 +1,14 @@
+use leptos::*;
+
+#[component]
+fn Component(children: Children) -> impl IntoView {
+    _ = children;
+}
+
+fn main() {
+    view! {
+        <Component let:a>
+            <p />
+        </Component>
+    };
+}

--- a/leptos_macro/tests/ui/view/expected_children_got_let_bind.stderr
+++ b/leptos_macro/tests/ui/view/expected_children_got_let_bind.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+  --> tests/ui/view/expected_children_got_let_bind.rs:11:13
+   |
+11 |             <p />
+   |             ^^^^^ expected `Box<dyn FnOnce() -> Fragment>`, found closure
+   |
+   = note: expected struct `Box<(dyn FnOnce() -> Fragment + 'static)>`
+             found closure `{closure@$DIR/tests/ui/view/expected_children_got_let_bind.rs:11:13: 11:18}`

--- a/leptos_macro/tests/ui/view/expected_children_got_let_bind_slot_version.rs
+++ b/leptos_macro/tests/ui/view/expected_children_got_let_bind_slot_version.rs
@@ -1,0 +1,21 @@
+use leptos::*;
+
+#[slot]
+struct Then {
+    children: Children,
+}
+
+#[component]
+fn Component(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+fn main() {
+    view! {
+        <Component>
+            <Then slot let:a>
+                <p />
+            </Then>
+        </Component>
+    };
+}

--- a/leptos_macro/tests/ui/view/expected_children_got_let_bind_slot_version.stderr
+++ b/leptos_macro/tests/ui/view/expected_children_got_let_bind_slot_version.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+  --> tests/ui/view/expected_children_got_let_bind_slot_version.rs:17:17
+   |
+17 |                 <p />
+   |                 ^^^^^ expected `Box<dyn FnOnce() -> Fragment>`, found closure
+   |
+   = note: expected struct `Box<(dyn FnOnce() -> Fragment + 'static)>`
+             found closure `{closure@$DIR/tests/ui/view/expected_children_got_let_bind_slot_version.rs:17:17: 17:22}`

--- a/leptos_macro/tests/ui/view/expected_one_let_bind_got_more.rs
+++ b/leptos_macro/tests/ui/view/expected_one_let_bind_got_more.rs
@@ -1,0 +1,21 @@
+use leptos::*;
+
+#[component]
+fn Component<C, IV>(children: C) -> impl IntoView
+where
+    C: Fn(String) -> IV,
+    IV: IntoView,
+{
+    _ = children;
+}
+
+fn main() {
+    view! {
+        <Component
+            let:item
+            let:extra_item
+        >
+            <p>{item}</p>
+        </Component>
+    };
+}

--- a/leptos_macro/tests/ui/view/expected_one_let_bind_got_more.stderr
+++ b/leptos_macro/tests/ui/view/expected_one_let_bind_got_more.stderr
@@ -1,0 +1,8 @@
+error[E0593]: closure is expected to take 1 argument, but it takes 2 arguments
+  --> tests/ui/view/expected_one_let_bind_got_more.rs:18:13
+   |
+18 |             <p>{item}</p>
+   |             ^^^^^^^^^^^^^
+   |             |
+   |             expected closure that takes 1 argument
+   |             takes 2 arguments

--- a/leptos_macro/tests/ui/view/expected_one_let_bind_got_more_slot_version.rs
+++ b/leptos_macro/tests/ui/view/expected_one_let_bind_got_more_slot_version.rs
@@ -1,0 +1,33 @@
+use leptos::*;
+
+#[slot]
+struct Then<C, IV>
+where
+    C: Fn(String) -> IV,
+    IV: IntoView,
+{
+    children: C,
+}
+
+#[component]
+fn Slot<C, IV>(then: Then<C, IV>) -> impl IntoView
+where
+    C: Fn(String) -> IV,
+    IV: IntoView,
+{
+    _ = then;
+}
+
+fn main() {
+    view! {
+        <Slot>
+            <Then
+                slot
+                let:item
+                let:extra_item
+            >
+                <p>{item}</p>
+            </Then>
+        </Slot>
+    };
+}

--- a/leptos_macro/tests/ui/view/expected_one_let_bind_got_more_slot_version.stderr
+++ b/leptos_macro/tests/ui/view/expected_one_let_bind_got_more_slot_version.stderr
@@ -1,0 +1,8 @@
+error[E0593]: closure is expected to take 1 argument, but it takes 2 arguments
+  --> tests/ui/view/expected_one_let_bind_got_more_slot_version.rs:29:17
+   |
+29 |                 <p>{item}</p>
+   |                 ^^^^^^^^^^^^^
+   |                 |
+   |                 expected closure that takes 1 argument
+   |                 takes 2 arguments

--- a/leptos_macro/tests/ui/view/expected_one_let_bind_got_none.rs
+++ b/leptos_macro/tests/ui/view/expected_one_let_bind_got_none.rs
@@ -1,0 +1,51 @@
+use leptos::*;
+
+#[slot]
+struct Then<T, C, RC>
+where
+    C: Fn(T) -> RC,
+    RC: IntoView,
+{
+    data: T,
+    children: C,
+}
+
+#[component]
+fn Slot<T, C, RC>(then: Then<T, C, RC>) -> impl IntoView
+where
+    C: Fn(T) -> RC,
+    RC: IntoView,
+{
+    _ = then;
+}
+
+#[component]
+fn Component<T, C, RC>(data: T, children: C) -> impl IntoView
+where
+    C: Fn(T) -> RC,
+    RC: IntoView,
+{
+    _ = data;
+    _ = children;
+}
+
+fn main() {
+    view! {
+        <Component
+            data=0
+        >
+            <p/>
+        </Component>
+    };
+
+    view! {
+        <Slot>
+            <Then
+                slot
+                data=0
+            >
+                <p/>
+            </Then>
+        </Slot>
+    };
+}

--- a/leptos_macro/tests/ui/view/expected_one_let_bind_got_none.stderr
+++ b/leptos_macro/tests/ui/view/expected_one_let_bind_got_none.stderr
@@ -1,0 +1,360 @@
+error[E0283]: type annotations needed for `ComponentProps<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:34:9
+   |
+34 | /         <Component
+35 | |             data=0
+36 | |         >
+37 | |             <p/>
+38 | |         </Component>
+   | |____________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required by a bound in `Component`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:25:8
+   |
+23 | fn Component<T, C, RC>(data: T, children: C) -> impl IntoView
+   |    --------- required by a bound in this function
+24 | where
+25 |     C: Fn(T) -> RC,
+   |        ^^^^^^^^^^^ required by this bound in `Component`
+help: consider giving `props` an explicit type, where the type for type parameter `C` is specified
+   |
+38 |         </Component>: ComponentProps<i32, C, RC>
+   |                     ++++++++++++++++++++++++++++
+
+error[E0283]: type annotations needed for `ComponentProps<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:34:9
+   |
+34 | /         <Component
+35 | |             data=0
+36 | |         >
+37 | |             <p/>
+38 | |         </Component>
+   | |____________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required by a bound in `ComponentPropsBuilder::<T, C, RC, (__data, ())>::children`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:25:8
+   |
+23 | fn Component<T, C, RC>(data: T, children: C) -> impl IntoView
+   |                                 -------- required by a bound in this associated function
+24 | where
+25 |     C: Fn(T) -> RC,
+   |        ^^^^^^^^^^^ required by this bound in `ComponentPropsBuilder::<T, C, RC, (__data, ())>::children`
+help: consider giving `props` an explicit type, where the type for type parameter `C` is specified
+   |
+38 |         </Component>: ComponentProps<i32, C, RC>
+   |                     ++++++++++++++++++++++++++++
+
+error[E0283]: type annotations needed for `ComponentProps<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:34:9
+   |
+34 | /         <Component
+35 | |             data=0
+36 | |         >
+37 | |             <p/>
+38 | |         </Component>
+   | |____________________^
+   |
+   = note: multiple `impl`s satisfying `_: ToChildren<{closure@$DIR/tests/ui/view/expected_one_let_bind_got_none.rs:37:13: 37:17}>` found in the `leptos` crate:
+           - impl<F> ToChildren<F> for Box<(dyn FnMut() -> Fragment + 'static)>
+             where <F as FnOnce<()>>::Output == Fragment, F: FnMut(), F: 'static;
+           - impl<F> ToChildren<F> for Box<(dyn FnOnce() -> Fragment + 'static)>
+             where <F as FnOnce<()>>::Output == Fragment, F: FnOnce(), F: 'static;
+           - impl<F> ToChildren<F> for Box<(dyn std::ops::Fn() -> Fragment + 'static)>
+             where <F as FnOnce<()>>::Output == Fragment, F: Fn(), F: 'static;
+           - impl<F> ToChildren<F> for Rc<(dyn std::ops::Fn() -> Fragment + 'static)>
+             where <F as FnOnce<()>>::Output == Fragment, F: Fn(), F: 'static;
+help: consider giving `props` an explicit type, where the placeholders `_` are specified
+   |
+38 |         </Component>: ComponentProps<i32, C, RC>
+   |                     ++++++++++++++++++++++++++++
+
+error[E0283]: type annotations needed for `ComponentProps<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:34:9
+   |
+34 |           <Component
+   |           ^--------- required by a bound introduced by this call
+   |  _________|
+   | |
+35 | |             data=0
+36 | |         >
+37 | |             <p/>
+38 | |         </Component>
+   | |____________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required by a bound in `ComponentPropsBuilder::<T, C, RC, ((T,), (C,))>::build`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:25:8
+   |
+22 | #[component]
+   | ------------ required by a bound in this associated function
+...
+25 |     C: Fn(T) -> RC,
+   |        ^^^^^^^^^^^ required by this bound in `ComponentPropsBuilder::<T, C, RC, ((T,), (C,))>::build`
+help: consider giving `props` an explicit type, where the type for type parameter `C` is specified
+   |
+38 |         </Component>: ComponentProps<i32, C, RC>
+   |                     ++++++++++++++++++++++++++++
+
+error[E0283]: type annotations needed for `ComponentProps<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:34:9
+   |
+34 | /         <Component
+35 | |             data=0
+36 | |         >
+37 | |             <p/>
+38 | |         </Component>
+   | |____________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required for `ComponentProps<i32, _, _>` to implement `leptos::Props`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:22:1
+   |
+22 | #[component]
+   | ^^^^^^^^^^^^
+...
+25 |     C: Fn(T) -> RC,
+   |        ----------- unsatisfied trait bound introduced here
+   = note: required for `ComponentProps<i32, _, _>` to implement `PropsOrNoPropsBuilder`
+   = note: required for `&fn(ComponentProps<i32, _, _>) -> impl leptos::IntoView {Component::<i32, _, _>}` to implement `ComponentConstructor<ComponentProps<i32, _, _>>`
+note: required by a bound in `component_view`
+  --> $WORKSPACE/leptos/src/lib.rs
+   |
+   | pub fn component_view<P>(f: impl ComponentConstructor<P>, props: P) -> View {
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `component_view`
+   = note: this error originates in the attribute macro `component` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider giving `props` an explicit type, where the type for type parameter `C` is specified
+   |
+38 |         </Component>: ComponentProps<i32, C, RC>
+   |                     ++++++++++++++++++++++++++++
+
+error[E0283]: type annotations needed for `Then<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:43:13
+   |
+42 |           <Slot>
+   |            ---- type must be known at this point
+43 | /             <Then
+44 | |                 slot
+45 | |                 data=0
+46 | |             >
+47 | |                 <p/>
+48 | |             </Then>
+   | |___________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required by a bound in `Slot`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:16:8
+   |
+14 | fn Slot<T, C, RC>(then: Then<T, C, RC>) -> impl IntoView
+   |    ---- required by a bound in this function
+15 | where
+16 |     C: Fn(T) -> RC,
+   |        ^^^^^^^^^^^ required by this bound in `Slot`
+help: consider giving `slot` an explicit type, where the type for type parameter `C` is specified
+   |
+48 |             </Then>: Then<i32, C, RC>
+   |                    ++++++++++++++++++
+
+error[E0283]: type annotations needed for `Then<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:43:13
+   |
+43 | /             <Then
+44 | |                 slot
+45 | |                 data=0
+46 | |             >
+47 | |                 <p/>
+48 | |             </Then>
+   | |___________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required by a bound in `SlotPropsBuilder::<T, C, RC>::then`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:16:8
+   |
+14 | fn Slot<T, C, RC>(then: Then<T, C, RC>) -> impl IntoView
+   |                   ---- required by a bound in this associated function
+15 | where
+16 |     C: Fn(T) -> RC,
+   |        ^^^^^^^^^^^ required by this bound in `SlotPropsBuilder::<T, C, RC>::then`
+help: consider giving `slot` an explicit type, where the type for type parameter `C` is specified
+   |
+48 |             </Then>: Then<i32, C, RC>
+   |                    ++++++++++++++++++
+
+error[E0283]: type annotations needed for `Then<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:43:13
+   |
+43 | /             <Then
+44 | |                 slot
+45 | |                 data=0
+46 | |             >
+47 | |                 <p/>
+48 | |             </Then>
+   | |___________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required by a bound in `Then`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:6:8
+   |
+4  | struct Then<T, C, RC>
+   |        ---- required by a bound in this struct
+5  | where
+6  |     C: Fn(T) -> RC,
+   |        ^^^^^^^^^^^ required by this bound in `Then`
+help: consider giving `slot` an explicit type, where the type for type parameter `C` is specified
+   |
+48 |             </Then>: Then<i32, C, RC>
+   |                    ++++++++++++++++++
+
+error[E0283]: type annotations needed for `Then<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:43:13
+   |
+43 | /             <Then
+44 | |                 slot
+45 | |                 data=0
+46 | |             >
+47 | |                 <p/>
+48 | |             </Then>
+   | |___________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required by a bound in `ThenBuilder::<T, C, RC, (__data, ())>::children`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:6:8
+   |
+6  |     C: Fn(T) -> RC,
+   |        ^^^^^^^^^^^ required by this bound in `ThenBuilder::<T, C, RC, (__data, ())>::children`
+...
+10 |     children: C,
+   |     -------- required by a bound in this associated function
+help: consider giving `slot` an explicit type, where the type for type parameter `C` is specified
+   |
+48 |             </Then>: Then<i32, C, RC>
+   |                    ++++++++++++++++++
+
+error[E0283]: type annotations needed for `Then<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:43:13
+   |
+43 | /             <Then
+44 | |                 slot
+45 | |                 data=0
+46 | |             >
+47 | |                 <p/>
+48 | |             </Then>
+   | |___________________^
+   |
+   = note: multiple `impl`s satisfying `_: ToChildren<{closure@$DIR/tests/ui/view/expected_one_let_bind_got_none.rs:47:17: 47:21}>` found in the `leptos` crate:
+           - impl<F> ToChildren<F> for Box<(dyn FnMut() -> Fragment + 'static)>
+             where <F as FnOnce<()>>::Output == Fragment, F: FnMut(), F: 'static;
+           - impl<F> ToChildren<F> for Box<(dyn FnOnce() -> Fragment + 'static)>
+             where <F as FnOnce<()>>::Output == Fragment, F: FnOnce(), F: 'static;
+           - impl<F> ToChildren<F> for Box<(dyn std::ops::Fn() -> Fragment + 'static)>
+             where <F as FnOnce<()>>::Output == Fragment, F: Fn(), F: 'static;
+           - impl<F> ToChildren<F> for Rc<(dyn std::ops::Fn() -> Fragment + 'static)>
+             where <F as FnOnce<()>>::Output == Fragment, F: Fn(), F: 'static;
+help: consider giving `slot` an explicit type, where the placeholders `_` are specified
+   |
+48 |             </Then>: Then<i32, C, RC>
+   |                    ++++++++++++++++++
+
+error[E0283]: type annotations needed for `Then<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:43:13
+   |
+42 |           <Slot>
+   |            ---- required by a bound introduced by this call
+43 | /             <Then
+44 | |                 slot
+45 | |                 data=0
+46 | |             >
+47 | |                 <p/>
+48 | |             </Then>
+   | |___________________^
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required by a bound in `SlotPropsBuilder::<T, C, RC, ((Then<T, C, RC>,),)>::build`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:16:8
+   |
+13 | #[component]
+   | ------------ required by a bound in this associated function
+...
+16 |     C: Fn(T) -> RC,
+   |        ^^^^^^^^^^^ required by this bound in `SlotPropsBuilder::<T, C, RC, ((Then<T, C, RC>,),)>::build`
+help: consider giving `slot` an explicit type, where the type for type parameter `C` is specified
+   |
+48 |             </Then>: Then<i32, C, RC>
+   |                    ++++++++++++++++++
+
+error[E0283]: type annotations needed for `Then<i32, C, RC>`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:43:13
+   |
+42 | /          <Slot>
+43 | |/             <Then
+44 | ||                 slot
+45 | ||                 data=0
+46 | ||             >
+47 | ||                 <p/>
+48 | ||             </Then>
+   | ||___________________^
+49 | |          </Slot>
+   | |________________- required by a bound introduced by this call
+   |
+   = note: multiple `impl`s satisfying `_: Fn(i32)` found in the following crates: `alloc`, `core`:
+           - impl<A, F> std::ops::Fn<A> for &F
+             where A: Tuple, F: std::ops::Fn<A>, F: ?Sized;
+           - impl<Args, F, A> std::ops::Fn<Args> for Box<F, A>
+             where Args: Tuple, F: std::ops::Fn<Args>, A: Allocator, F: ?Sized;
+note: required for `SlotProps<i32, _, _>` to implement `leptos::Props`
+  --> tests/ui/view/expected_one_let_bind_got_none.rs:13:1
+   |
+13 | #[component]
+   | ^^^^^^^^^^^^
+...
+16 |     C: Fn(T) -> RC,
+   |        ----------- unsatisfied trait bound introduced here
+   = note: required for `SlotProps<i32, _, _>` to implement `PropsOrNoPropsBuilder`
+   = note: required for `&fn(SlotProps<i32, _, _>) -> impl leptos::IntoView {Slot::<i32, _, _>}` to implement `ComponentConstructor<SlotProps<i32, _, _>>`
+note: required by a bound in `component_view`
+  --> $WORKSPACE/leptos/src/lib.rs
+   |
+   | pub fn component_view<P>(f: impl ComponentConstructor<P>, props: P) -> View {
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `component_view`
+   = note: this error originates in the attribute macro `component` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider giving `slot` an explicit type, where the type for type parameter `C` is specified
+   |
+48 |             </Then>: Then<i32, C, RC>
+   |                    ++++++++++++++++++

--- a/leptos_macro/tests/ui/view/generics.rs
+++ b/leptos_macro/tests/ui/view/generics.rs
@@ -1,0 +1,16 @@
+use leptos::*;
+
+#[component]
+fn Component<T: Into<String>>(prop: T) -> impl IntoView {
+    _ = prop;
+}
+
+fn main() {
+    view! {
+        <Component<i32> prop=0 />
+    };
+
+    view! {
+        <Component prop=0 />
+    };
+}

--- a/leptos_macro/tests/ui/view/generics.stderr
+++ b/leptos_macro/tests/ui/view/generics.stderr
@@ -1,0 +1,124 @@
+error[E0277]: the trait bound `std::string::String: From<i32>` is not satisfied
+  --> tests/ui/view/generics.rs:10:20
+   |
+10 |         <Component<i32> prop=0 />
+   |                    ^^^ the trait `From<i32>` is not implemented for `std::string::String`
+   |
+   = help: the following other types implement trait `From<T>`:
+             <std::string::String as From<char>>
+             <std::string::String as From<Box<str>>>
+             <std::string::String as From<Oco<'_, str>>>
+             <std::string::String as From<Cow<'a, str>>>
+             <std::string::String as From<url::Url>>
+             <std::string::String as From<js_sys::JsString>>
+             <std::string::String as From<&'a js_sys::JsString>>
+             <std::string::String as From<&str>>
+           and $N others
+   = note: required for `i32` to implement `Into<std::string::String>`
+note: required by a bound in `Component`
+  --> tests/ui/view/generics.rs:4:17
+   |
+4  | fn Component<T: Into<String>>(prop: T) -> impl IntoView {
+   |                 ^^^^^^^^^^^^ required by this bound in `Component`
+
+error[E0277]: the trait bound `fn(ComponentProps<i32>) -> impl leptos::IntoView {Component::<i32>}: leptos::Component<_>` is not satisfied
+  --> tests/ui/view/generics.rs:10:10
+   |
+10 |         <Component<i32> prop=0 />
+   |          ---------^^^^^
+   |          |
+   |          the trait `leptos::Component<_>` is not implemented for fn item `fn(ComponentProps<i32>) -> impl leptos::IntoView {Component::<i32>}`
+   |          required by a bound introduced by this call
+   |
+note: required by a bound in `component_props_builder`
+  --> $WORKSPACE/leptos/src/lib.rs
+   |
+   | pub fn component_props_builder<P: PropsOrNoPropsBuilder>(
+   |        ----------------------- required by a bound in this function
+   |     _f: &impl Component<P>,
+   |               ^^^^^^^^^^^^ required by this bound in `component_props_builder`
+
+error[E0277]: the trait bound `std::string::String: From<i32>` is not satisfied
+  --> tests/ui/view/generics.rs:10:10
+   |
+10 |         <Component<i32> prop=0 />
+   |          ^^^^^^^^^ the trait `From<i32>` is not implemented for `std::string::String`
+   |
+   = help: the following other types implement trait `From<T>`:
+             <std::string::String as From<char>>
+             <std::string::String as From<Box<str>>>
+             <std::string::String as From<Oco<'_, str>>>
+             <std::string::String as From<Cow<'a, str>>>
+             <std::string::String as From<url::Url>>
+             <std::string::String as From<js_sys::JsString>>
+             <std::string::String as From<&'a js_sys::JsString>>
+             <std::string::String as From<&str>>
+           and $N others
+   = note: required for `i32` to implement `Into<std::string::String>`
+note: required by a bound in `Component`
+  --> tests/ui/view/generics.rs:4:17
+   |
+4  | fn Component<T: Into<String>>(prop: T) -> impl IntoView {
+   |                 ^^^^^^^^^^^^ required by this bound in `Component`
+
+error[E0277]: the trait bound `std::string::String: From<{integer}>` is not satisfied
+  --> tests/ui/view/generics.rs:14:20
+   |
+14 |         <Component prop=0 />
+   |                    ^^^^ the trait `From<{integer}>` is not implemented for `std::string::String`
+   |
+   = help: the following other types implement trait `From<T>`:
+             <std::string::String as From<char>>
+             <std::string::String as From<Box<str>>>
+             <std::string::String as From<Oco<'_, str>>>
+             <std::string::String as From<Cow<'a, str>>>
+             <std::string::String as From<url::Url>>
+             <std::string::String as From<js_sys::JsString>>
+             <std::string::String as From<&'a js_sys::JsString>>
+             <std::string::String as From<&str>>
+           and $N others
+   = note: required for `{integer}` to implement `Into<std::string::String>`
+note: required by a bound in `ComponentPropsBuilder::<T>::prop`
+  --> tests/ui/view/generics.rs:4:17
+   |
+4  | fn Component<T: Into<String>>(prop: T) -> impl IntoView {
+   |                 ^^^^^^^^^^^^ required by this bound in `ComponentPropsBuilder::<T>::prop`
+
+error[E0277]: the trait bound `std::string::String: From<{integer}>` is not satisfied
+  --> tests/ui/view/generics.rs:14:10
+   |
+14 |         <Component prop=0 />
+   |          ^^^^^^^^^ the trait `From<{integer}>` is not implemented for `std::string::String`
+   |
+   = help: the following other types implement trait `From<T>`:
+             <std::string::String as From<char>>
+             <std::string::String as From<Box<str>>>
+             <std::string::String as From<Oco<'_, str>>>
+             <std::string::String as From<Cow<'a, str>>>
+             <std::string::String as From<url::Url>>
+             <std::string::String as From<js_sys::JsString>>
+             <std::string::String as From<&'a js_sys::JsString>>
+             <std::string::String as From<&str>>
+           and $N others
+   = note: required for `{integer}` to implement `Into<std::string::String>`
+note: required by a bound in `Component`
+  --> tests/ui/view/generics.rs:4:17
+   |
+4  | fn Component<T: Into<String>>(prop: T) -> impl IntoView {
+   |                 ^^^^^^^^^^^^ required by this bound in `Component`
+
+error[E0599]: the method `build` exists for struct `ComponentPropsBuilder<{integer}, (({integer},),)>`, but its trait bounds were not satisfied
+  --> tests/ui/view/generics.rs:14:10
+   |
+3  | #[component]
+   | ------------ method `build` not found for this struct
+...
+14 |         <Component prop=0 />
+   |          ^^^^^^^^^ method cannot be called on `ComponentPropsBuilder<{integer}, (({integer},),)>` due to unsatisfied trait bounds
+   |
+note: trait bound `{integer}: Into<std::string::String>` was not satisfied
+  --> tests/ui/view/generics.rs:3:1
+   |
+3  | #[component]
+   | ^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   = note: this error originates in the attribute macro `component` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/leptos_macro/tests/ui/view/missing_field.rs
+++ b/leptos_macro/tests/ui/view/missing_field.rs
@@ -1,0 +1,12 @@
+use leptos::*;
+
+#[component]
+fn Component(prop: i32) -> impl IntoView {
+    _ = prop;
+}
+
+fn main() {
+    view! {
+        <Component />
+    };
+}

--- a/leptos_macro/tests/ui/view/missing_field.stderr
+++ b/leptos_macro/tests/ui/view/missing_field.stderr
@@ -1,0 +1,24 @@
+warning: use of deprecated method `ComponentPropsBuilder::build`: Missing required field prop
+  --> tests/ui/view/missing_field.rs:10:10
+   |
+10 |         <Component />
+   |          ^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error[E0061]: this method takes 1 argument but 0 arguments were supplied
+  --> tests/ui/view/missing_field.rs:10:10
+   |
+10 |         <Component />
+   |          ^^^^^^^^^ an argument of type `ComponentPropsBuilder_Error_Missing_required_field_prop` is missing
+   |
+note: method defined here
+  --> tests/ui/view/missing_field.rs:3:1
+   |
+3  | #[component]
+   | ^^^^^^^^^^^^
+   = note: this error originates in the derive macro `::leptos::typed_builder_macro::TypedBuilder` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: provide the argument
+   |
+10 |         <Component(/* ComponentPropsBuilder_Error_Missing_required_field_prop */) />
+   |                   +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/leptos_macro/tests/ui/view/prop_into.rs
+++ b/leptos_macro/tests/ui/view/prop_into.rs
@@ -1,0 +1,18 @@
+use leptos::*;
+
+#[component]
+fn Component(#[prop(into)] prop: MaybeSignal<String>) -> impl IntoView {
+    _ = prop;
+}
+
+fn main() {
+    view! {
+        <Component prop=move || String::new() />
+    };
+
+    let prop = move || String::new();
+
+    view! {
+        <Component prop />
+    };
+}

--- a/leptos_macro/tests/ui/view/prop_into.stderr
+++ b/leptos_macro/tests/ui/view/prop_into.stderr
@@ -1,0 +1,37 @@
+error[E0277]: the trait bound `leptos::MaybeSignal<std::string::String>: From<{closure@$DIR/tests/ui/view/prop_into.rs:10:25: 10:32}>` is not satisfied
+  --> tests/ui/view/prop_into.rs:10:25
+   |
+10 |         <Component prop=move || String::new() />
+   |                    ---- ^^^^^^^^^^^^^^^^^^^^^ the trait `From<{closure@$DIR/tests/ui/view/prop_into.rs:10:25: 10:32}>` is not implemented for `leptos::MaybeSignal<std::string::String>`
+   |                    |
+   |                    required by a bound introduced by this call
+   |
+   = help: the trait `From<&str>` is implemented for `leptos::MaybeSignal<std::string::String>`
+   = help: for that trait implementation, expected `&str`, found `{closure@$DIR/tests/ui/view/prop_into.rs:10:25: 10:32}`
+   = note: required for `{closure@$DIR/tests/ui/view/prop_into.rs:10:25: 10:32}` to implement `Into<leptos::MaybeSignal<std::string::String>>`
+note: required by a bound in `ComponentPropsBuilder::prop`
+  --> tests/ui/view/prop_into.rs:3:1
+   |
+3  | #[component]
+   | ^^^^^^^^^^^^ required by this bound in `ComponentPropsBuilder::prop`
+4  | fn Component(#[prop(into)] prop: MaybeSignal<String>) -> impl IntoView {
+   |                            ---- required by a bound in this associated function
+   = note: this error originates in the derive macro `::leptos::typed_builder_macro::TypedBuilder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `leptos::MaybeSignal<std::string::String>: From<{closure@$DIR/tests/ui/view/prop_into.rs:13:16: 13:23}>` is not satisfied
+  --> tests/ui/view/prop_into.rs:16:20
+   |
+16 |         <Component prop />
+   |                    ^^^^ the trait `From<{closure@$DIR/tests/ui/view/prop_into.rs:13:16: 13:23}>` is not implemented for `leptos::MaybeSignal<std::string::String>`
+   |
+   = help: the trait `From<&str>` is implemented for `leptos::MaybeSignal<std::string::String>`
+   = help: for that trait implementation, expected `&str`, found `{closure@$DIR/tests/ui/view/prop_into.rs:13:16: 13:23}`
+   = note: required for `{closure@$DIR/tests/ui/view/prop_into.rs:13:16: 13:23}` to implement `Into<leptos::MaybeSignal<std::string::String>>`
+note: required by a bound in `ComponentPropsBuilder::prop`
+  --> tests/ui/view/prop_into.rs:3:1
+   |
+3  | #[component]
+   | ^^^^^^^^^^^^ required by this bound in `ComponentPropsBuilder::prop`
+4  | fn Component(#[prop(into)] prop: MaybeSignal<String>) -> impl IntoView {
+   |                            ---- required by a bound in this associated function
+   = note: this error originates in the derive macro `::leptos::typed_builder_macro::TypedBuilder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/leptos_macro/tests/ui/view/slot_expected_one_got_more.rs
+++ b/leptos_macro/tests/ui/view/slot_expected_one_got_more.rs
@@ -1,0 +1,31 @@
+use leptos::*;
+
+#[slot]
+struct Then {}
+
+#[component]
+fn SlotIf(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+#[component]
+fn If(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+fn main() {
+    view! {
+        <If>
+            <Then slot />
+            <Then slot />
+        </If>
+    };
+
+    view! {
+        <SlotIf>
+            <Then slot />
+            <Then slot />
+        </SlotIf>
+
+    };
+}

--- a/leptos_macro/tests/ui/view/slot_expected_one_got_more.stderr
+++ b/leptos_macro/tests/ui/view/slot_expected_one_got_more.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> tests/ui/view/slot_expected_one_got_more.rs:20:13
+   |
+20 |             <Then slot />
+   |             ^^^^^^^^^^^^^
+   |             |
+   |             expected `Then`, found `Vec<_>`
+   |             arguments to this method are incorrect
+   |
+   = note: expected struct `Then`
+              found struct `Vec<_>`
+note: method defined here
+  --> tests/ui/view/slot_expected_one_got_more.rs:12:7
+   |
+12 | fn If(then: Then) -> impl IntoView {
+   |       ^^^^------
+   = note: this error originates in the macro `::std::vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui/view/slot_expected_one_got_more.rs:27:13
+   |
+27 |             <Then slot />
+   |             ^^^^^^^^^^^^^
+   |             |
+   |             expected `Then`, found `Vec<_>`
+   |             arguments to this method are incorrect
+   |
+   = note: expected struct `Then`
+              found struct `Vec<_>`
+note: method defined here
+  --> tests/ui/view/slot_expected_one_got_more.rs:7:11
+   |
+7  | fn SlotIf(then: Then) -> impl IntoView {
+   |           ^^^^------
+   = note: this error originates in the macro `::std::vec` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/leptos_macro/tests/ui/view/slot_missing_field.rs
+++ b/leptos_macro/tests/ui/view/slot_missing_field.rs
@@ -1,0 +1,19 @@
+use leptos::*;
+
+#[slot]
+struct Then {
+    a: i32,
+}
+
+#[component]
+fn SlotIf(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+fn main() {
+    view! {
+        <SlotIf>
+            <Then slot />
+        </SlotIf>
+    };
+}

--- a/leptos_macro/tests/ui/view/slot_missing_field.stderr
+++ b/leptos_macro/tests/ui/view/slot_missing_field.stderr
@@ -1,0 +1,24 @@
+warning: use of deprecated method `ThenBuilder::build`: Missing required field a
+  --> tests/ui/view/slot_missing_field.rs:16:14
+   |
+16 |             <Then slot />
+   |              ^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error[E0061]: this method takes 1 argument but 0 arguments were supplied
+  --> tests/ui/view/slot_missing_field.rs:16:14
+   |
+16 |             <Then slot />
+   |              ^^^^ an argument of type `ThenBuilder_Error_Missing_required_field_a` is missing
+   |
+note: method defined here
+  --> tests/ui/view/slot_missing_field.rs:3:1
+   |
+3  | #[slot]
+   | ^^^^^^^
+   = note: this error originates in the derive macro `::leptos::typed_builder_macro::TypedBuilder` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: provide the argument
+   |
+16 |             <Then(/* ThenBuilder_Error_Missing_required_field_a */) slot />
+   |                  ++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/leptos_macro/tests/ui/view/slot_unreachable_code.rs
+++ b/leptos_macro/tests/ui/view/slot_unreachable_code.rs
@@ -1,0 +1,19 @@
+use leptos::*;
+
+#[slot]
+struct Then {
+    a: i32,
+}
+
+#[component]
+fn SlotIf(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+fn main() {
+    view! {
+        <SlotIf>
+            <Then slot />
+        </SlotIf>
+    };
+}

--- a/leptos_macro/tests/ui/view/slot_unreachable_code.stderr
+++ b/leptos_macro/tests/ui/view/slot_unreachable_code.stderr
@@ -1,0 +1,24 @@
+warning: use of deprecated method `ThenBuilder::build`: Missing required field a
+  --> tests/ui/view/slot_unreachable_code.rs:16:14
+   |
+16 |             <Then slot />
+   |              ^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error[E0061]: this method takes 1 argument but 0 arguments were supplied
+  --> tests/ui/view/slot_unreachable_code.rs:16:14
+   |
+16 |             <Then slot />
+   |              ^^^^ an argument of type `ThenBuilder_Error_Missing_required_field_a` is missing
+   |
+note: method defined here
+  --> tests/ui/view/slot_unreachable_code.rs:3:1
+   |
+3  | #[slot]
+   | ^^^^^^^
+   = note: this error originates in the derive macro `::leptos::typed_builder_macro::TypedBuilder` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: provide the argument
+   |
+16 |             <Then(/* ThenBuilder_Error_Missing_required_field_a */) slot />
+   |                  ++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/leptos_macro/tests/ui/view/slots_prop_into.rs
+++ b/leptos_macro/tests/ui/view/slots_prop_into.rs
@@ -1,0 +1,37 @@
+use leptos::*;
+
+#[slot]
+struct Then {
+    children: ChildrenFn,
+}
+
+#[slot]
+struct ElseIf {
+    #[prop(into)]
+    cond: MaybeSignal<bool>,
+    children: ChildrenFn,
+}
+
+#[component]
+fn SlotIf(
+    #[prop(into)] cond: MaybeSignal<bool>,
+    then: Then,
+    #[prop(optional)] else_if: Vec<ElseIf>,
+) -> impl IntoView {
+    _ = cond;
+    _ = then;
+    _ = else_if;
+}
+
+fn main() {
+    let (count, set_count) = create_signal(0);
+    let is_even = MaybeSignal::derive(move || count.get() % 2 == 0);
+    let is_div5 = move || count.get() % 5 == 0;
+
+    view! {
+        <SlotIf cond=is_even>
+            <Then slot>"even"</Then>
+            <ElseIf slot cond=is_div5>"divisible by 5"</ElseIf>
+        </SlotIf>
+    };
+}

--- a/leptos_macro/tests/ui/view/slots_prop_into.stderr
+++ b/leptos_macro/tests/ui/view/slots_prop_into.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `leptos::MaybeSignal<bool>: From<{closure@$DIR/tests/ui/view/slots_prop_into.rs:29:19: 29:26}>` is not satisfied
+  --> tests/ui/view/slots_prop_into.rs:34:31
+   |
+34 |             <ElseIf slot cond=is_div5>"divisible by 5"</ElseIf>
+   |                          ---- ^^^^^^^ the trait `From<{closure@$DIR/tests/ui/view/slots_prop_into.rs:29:19: 29:26}>` is not implemented for `leptos::MaybeSignal<bool>`
+   |                          |
+   |                          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `From<T>`:
+             <leptos::MaybeSignal<std::string::String> as From<&str>>
+             <leptos::MaybeSignal<T> as From<ReadSignal<T>>>
+             <leptos::MaybeSignal<T> as From<RwSignal<T>>>
+             <leptos::MaybeSignal<T> as From<Memo<T>>>
+             <leptos::MaybeSignal<T> as From<Signal<T>>>
+             <leptos::MaybeSignal<T> as From<T>>
+   = note: required for `{closure@$DIR/tests/ui/view/slots_prop_into.rs:29:19: 29:26}` to implement `Into<leptos::MaybeSignal<bool>>`
+note: required by a bound in `ElseIfBuilder::<((), __children)>::cond`
+  --> tests/ui/view/slots_prop_into.rs:8:1
+   |
+8  | #[slot]
+   | ^^^^^^^ required by this bound in `ElseIfBuilder::<((), __children)>::cond`
+...
+11 |     cond: MaybeSignal<bool>,
+   |     ---- required by a bound in this associated function
+   = note: this error originates in the derive macro `::leptos::typed_builder_macro::TypedBuilder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/leptos_macro/tests/ui/view/undefined_slot.rs
+++ b/leptos_macro/tests/ui/view/undefined_slot.rs
@@ -1,0 +1,34 @@
+use leptos::*;
+
+#[slot]
+struct Then {}
+
+#[slot]
+struct ElseIf {
+    #[prop(optional)]
+    then: Option<Then>,
+}
+
+#[component]
+fn If(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+#[component]
+fn SlotIf(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+fn main() {
+    view! {
+        <If>
+            <ElseIf slot />
+        </If>
+    };
+
+    view! {
+        <SlotIf>
+            <ElseIf slot />
+        </SlotIf>
+    };
+}

--- a/leptos_macro/tests/ui/view/undefined_slot.stderr
+++ b/leptos_macro/tests/ui/view/undefined_slot.stderr
@@ -1,0 +1,25 @@
+error[E0599]: no method named `else_if` found for struct `IfPropsBuilder` in the current scope
+  --> tests/ui/view/undefined_slot.rs:25:13
+   |
+12 |   #[component]
+   |   ------------ method `else_if` not found for this struct
+...
+23 | /     view! {
+24 | |         <If>
+25 | |             <ElseIf slot />
+   | |            -^^^^^^^^^^^^^^^ method not found in `IfPropsBuilder`
+   | |____________|
+   |
+
+error[E0599]: no method named `else_if` found for struct `SlotIfPropsBuilder` in the current scope
+  --> tests/ui/view/undefined_slot.rs:31:13
+   |
+17 |   #[component]
+   |   ------------ method `else_if` not found for this struct
+...
+29 | /     view! {
+30 | |         <SlotIf>
+31 | |             <ElseIf slot />
+   | |            -^^^^^^^^^^^^^^^ method not found in `SlotIfPropsBuilder`
+   | |____________|
+   |

--- a/leptos_macro/tests/ui/view/wrong_slot_name.rs
+++ b/leptos_macro/tests/ui/view/wrong_slot_name.rs
@@ -1,0 +1,31 @@
+use leptos::*;
+
+#[slot]
+struct Then {}
+
+#[slot]
+struct ElseIf {}
+
+#[component]
+fn If(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+#[component]
+fn SlotIf(then: Then) -> impl IntoView {
+    _ = then;
+}
+
+fn main() {
+    view! {
+        <If>
+            <ElseIf slot:then />
+        </If>
+    };
+
+    view! {
+        <SlotIf>
+            <ElseIf slot:then />
+        </SlotIf>
+    };
+}

--- a/leptos_macro/tests/ui/view/wrong_slot_name.stderr
+++ b/leptos_macro/tests/ui/view/wrong_slot_name.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `Then: From<ElseIf>` is not satisfied
+  --> tests/ui/view/wrong_slot_name.rs:22:13
+   |
+22 |             <ElseIf slot:then />
+   |             ^^^^^^^^^^^^^^^^^^^^ the trait `From<ElseIf>` is not implemented for `Then`
+   |
+   = note: required for `ElseIf` to implement `Into<Then>`
+
+error[E0277]: the trait bound `Then: From<ElseIf>` is not satisfied
+  --> tests/ui/view/wrong_slot_name.rs:28:13
+   |
+28 |             <ElseIf slot:then />
+   |             ^^^^^^^^^^^^^^^^^^^^ the trait `From<ElseIf>` is not implemented for `Then`
+   |
+   = note: required for `ElseIf` to implement `Into<Then>`


### PR DESCRIPTION
This PR is aimed to improve DX of using leptos by fixing error reporting in `view!` macro, so that errors inside it are reported over the token, that caused an error, instead of the whole `view!` macro call site.

Here is a simple example:

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/1ae27701-7906-47bc-9ac9-c29bc152f6ca)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/0a594270-a7d6-4109-b72e-01eae5f60595)

<details>
<summary><h2>List of all errors that are covered by this PR</h2></summary>

### `unreachable_code`/`missing_field`
Disable "unreachable_code" lint when there is an error `view!` macro

Report "missing field" and other `.build()` errors on component's name

**Regression:** "Go to Definition" triggered on `Component` name in `view!` macro now suggests `build` method definition in addition to `Component` itself. Previously only `Component` was reported

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/4af76734-6378-4c09-ad71-1251affa5126)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/1e164aa9-2578-4baa-8c81-d03185ff1060)

### `component_with_props_without_macro`
Component with props but without `#[component]` macro is used in `view!` macro

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/60c5d424-b75f-406a-b400-c61a38d8f7a3)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/2538c89d-170d-4091-9c34-5f483cfe356a)

### `generics`
When incorrect generics are passed or inferred in component the error is reported over the whole `view!` macro.

**Regression:** "Go to Definition" triggered on `Component` name in `view!` macro now suggests `leptos::component_props_builder` definition in addition to `Component` itself.

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/1dcd733c-c085-4fd4-aea0-845f280ee957)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/1724559b-ac92-40d4-b298-c37d0f849426)

### `prop_into`
Error reporting with `#[prop(into)]`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/c4b06238-5ab3-43d2-9896-848faabe0ea4)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/7d51a514-3737-422a-98f0-ef8b0f56acbd)

### `events`
Error for "on:" events should be reported on it's name

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/d3c590b4-f656-4cfc-b4de-fce2c5a44998)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/a3fd6f0d-4e05-4a63-ae1f-09bf148a3c83)

### `directive`
Missing or incorrect type of the param when using directive

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/5a9a7d67-cfef-4df9-9c54-5f764c9dec72)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/8f251977-77c1-447f-9788-1a441d97488d)

### `block_in_fragment`
If block inside fragment returns something, that is not "renderable"

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/aec1bd6e-7e88-479e-b798-ebc368348032)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/f988e286-f38e-4763-8b7d-cfc03566671d)

### `slots_prop_into`
Error reporting with `#[prop(into)]` in slots

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/87719604-b7b5-45ef-9dcd-f553e67cc000)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/ca3942a5-d388-493c-952b-8db85b47480f)

### `wrong_slot_name`
Wrong slot name

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/22e891dd-542e-4794-9080-ec823583a2b8)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/3a91a0f9-1621-4be1-a3e5-24cd1753b496)

### `undefined_slot`
Using slot that is not defined in a component

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/e3939687-fac4-471e-8419-d811e5cbef71)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/2353c712-8054-4d81-8df2-b380bbf90d10)

### `slot_expected_one_got_more`
Expected one slot, got more

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/014345aa-d521-4373-8961-de1e6f785dc4)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/43147aec-4518-4ccc-a990-d5cb31777779)

###  `slot_unreachable_code`/`slot_missing_field`
Disable "unreachable_code" warn when there is an error in slot in `view!` macro

Report "missing field" and other `.build()` errors on slot's name

**Regression:** "Go to Definition" triggered on `Then` in `view!` macro now suggests `build` method definition in addition to `Then` itself. Previously only `Then` was reported

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/8360993b-c752-4b48-8e1e-87e5263c040d)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/87367e7d-5db9-4060-a8a1-4cee29f00bf0)

### `children_clone`
Using `clone:` notation on type that does not implement clone

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/0d57cf64-e1a2-4748-9af5-1f48828da16a)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/ec5b99a4-6b46-442d-bf80-99a6356d7a04)

### `children_let_expected_one_got_none`
Expected `let:` binding, got `Children`.

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/bc10ff67-961f-450a-8045-67dba088e227)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/58a99184-3643-4205-9d04-356d9cd16d5f)

### `children_projection_error`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/2c5f7299-4638-44a5-a3de-b87a86b8941f)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/5c4b5cfd-557f-4db6-a032-db98ba91d72b)

### `children_projection_error_slot_version`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/6dac1c8a-2c86-49ff-ad4f-7e1ef7beb1dd)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/e185fee8-cfb8-4ead-a0e5-c9833fb88206)

### `expected_children_got_let_bind`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/c0750e3e-6f0f-4097-8d87-3367d5dbb7ac)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/4619ef71-2e14-42c1-b66f-deafccbe98a8)

### `expected_children_got_let_bind_slot_version`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/74856e08-1a0c-4b2b-8418-b9feb8cd1a07)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/a8db68bd-eb47-4783-94c1-84b24d684280)

### `expected_one_let_bind_got_more`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/a149950a-279d-4447-afd6-448f7a14e601)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/5ac2b70f-0982-4289-8e00-df438da93453)

### `expected_one_let_bind_got_more_slot_version`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/52aac51f-06d3-4ff9-aff1-a48d75ae2265)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/3e31dde6-9d76-409f-a0f8-0d55e79e2de9)

### `element_incorrect_attribute_type`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/3c5bb9d1-3d08-42df-9cf9-59f1a6cc966d)
--------|------
After |  ![image](https://github.com/Ar4ys/leptos/assets/37052349/5d0589c3-c8ff-4682-a322-b4706b8708ca)

### `element_incorrect_spread_type`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/a3fcf01a-5fff-4e2f-87f2-d01896b5f912)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/0e19500b-6127-43dd-919b-362dc4c74c40)

### `element_incorrect_child_type`

Before | ![image](https://github.com/Ar4ys/leptos/assets/37052349/eaca0900-6ded-4936-b4fb-5a2a7e1a6602)
--------|------
After | ![image](https://github.com/Ar4ys/leptos/assets/37052349/c3d3f81b-f860-43e0-8db4-52ebdc4f7333)

</details>

> [!NOTE]
> There are also some regressions regarding "Go to Definition" LSP functionality - in some cases it now suggests implementation details alongside original definition. See `missing_field`, `generics` and `slot_missing_field`. Although it makes DX of using "Go to Definition" worse than before - I believe it's a fair trade-off for correct error reporting.

*Almost* all examples listed above have a corresponding test case in `leptos_macro/tests/ui/view`. Some tests have subtly different output between ssr and client modes.

<details>
<summary>Example</summary>

```rust
EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0277]: expected a `Fn()` closure, found `A`
 --> tests/ui/view/element/incorrect_child_type.rs:7:14
  |
6 | /     view! {
7 | |         <div>{A}</div>
  | |              ^-^
  | |              ||
  | |              |this tail expression is of type `A`
  | |              expected an `Fn()` closure, found `A`
8 | |     };
  | |_____- required by a bound introduced by this call
  |
  = help: the trait `std::ops::Fn<()>` is not implemented for `A`
  = note: wrap the `A` in a closure with no arguments: `|| { /* code */ }`
  = help: the following other types implement trait `IntoView`:
            bool
            char
            isize
            i8
            i16
            i32
            i64
            i128
          and $N others
  = note: required for `A` to implement `IntoView`
help: you might have meant to create the closure instead of a block
  |
7 |         <div>|_| {A}</div>
  |              +++
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0277]: expected a `Fn()` closure, found `A`
 --> tests/ui/view/element/incorrect_child_type.rs:7:14
  |
6 | /     view! {
7 | |         <div>{A}</div>
  | |              ^-^
  | |              ||
  | |              |this tail expression is of type `A`
  | |              expected an `Fn()` closure, found `A`
8 | |     };
  | |_____- required by a bound introduced by this call
  |
  = help: the trait `std::ops::Fn<()>` is not implemented for `A`
  = note: wrap the `A` in a closure with no arguments: `|| { /* code */ }`
  = help: the following other types implement trait `IntoView`:
            bool
            char
            isize
            i8
            i16
            i32
            i64
            i128
          and $N others
  = note: required for `A` to implement `IntoView`
note: required by a bound in `HtmlElement::<El>::child`
 --> $WORKSPACE/leptos_dom/src/html.rs
  |
  |     pub fn child(self, child: impl IntoView) -> Self {
  |                                    ^^^^^^^^ required by this bound in `HtmlElement::<El>::child`
help: you might have meant to create the closure instead of a block
  |
7 |         <div>|_| {A}</div>
  |              +++
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```
</details>

<details>
<summary>List of all <i>problematic</i> tests</summary>

```rust
use leptos::*;

struct A;

fn incorrect_attribute_type() {
    view! {
        <div id=A />
    };
}

fn incorrect_child_type() {
    view! {
        <div>{A}</div>
    };
}

fn incorrect_class_type() {
    view! {
        <div class:id=A />
    };
}

fn incorrect_fancy_class_type() {
    view! {
        <div class=("id", A) />
    };
}

fn incorrect_global_class_type() {
    view! { class=A,
        <div />
    };
}

fn incorrect_style_type() {
    view! {
        <div style:id=A />
    };
}

fn incorrect_fancy_style_type() {
    view! {
        <div style=("id", A) />
    };
}


fn incorrect_event_type() {
    view! {
        <div on:click=A />
    };
}

// `prop:` are not currently checked in ssr at all
fn incorrect_prop_type() {
    view! {
        <div prop:id=A />
    };
}

fn incorrect_spread_type() {
    view! {
        <div {..A} />
    };
}
```
</details>

Unfortunately, there is no easy way to implement these tests, because maintainer of `trybuild` crate refuses to allow specifying custom suffix on `TestCases`: https://github.com/dtolnay/trybuild/issues/245. Currently, I see 4 possible ways about this:
- Duplicate these tests in separate folders (`view_ssr` and `view_client`) and load them conditionally (based on current feature flags)
- Fork `trybuild` crate and add suffix functionality
- "Add code in the test to rename the right set of files to .stderr before calling into trybuild" - suggestion from maintainer of `trybuild`
- Just ignore these tests and hope DX will not degrade in the future